### PR TITLE
Add support for CArrowArrayStream

### DIFF
--- a/firebolt/buffers.mojo
+++ b/firebolt/buffers.mojo
@@ -331,7 +331,9 @@ struct Bitmap(Movable, Writable):
             buffer_value = buffer_value & ~mask
         self.buffer.unsafe_set[DType.uint8](byte_index, buffer_value)
 
-    fn unsafe_range_set(mut self, start: Int, length: Int, value: Bool) -> None:
+    fn unsafe_range_set[
+        T: Intable, U: Intable, //
+    ](mut self, start: T, length: U, value: Bool) -> None:
         """Set a range of bits in the bitmap to the specified value.
 
         Args:
@@ -341,10 +343,12 @@ struct Bitmap(Movable, Writable):
         """
 
         # Process the partial byte at the ends.
-        var start_index = start // 8
-        var bit_pos_start = start % 8
-        var end_index = (start + length) // 8
-        var bit_pos_end = (start + length) % 8
+        var start_int = Int(start)
+        var end_int = start_int + Int(length)
+        var start_index = start_int // 8
+        var bit_pos_start = start_int % 8
+        var end_index = end_int // 8
+        var bit_pos_end = end_int % 8
 
         if bit_pos_start != 0 or bit_pos_end != 0:
             if start_index == end_index:

--- a/firebolt/dtypes.mojo
+++ b/firebolt/dtypes.mojo
@@ -250,8 +250,12 @@ struct DataType(Copyable, EqualityComparable, Movable, Stringable):
             return "int8"
         elif self.code == INT16:
             return "int16"
+        elif self.code == INT32:
+            return "int32"
+        elif self.code == STRUCT:
+            return "struct"
         else:
-            return "unknown"
+            return "unknown " + String(self.code)
 
     fn is_bool(self) -> Bool:
         return self.code == BOOL

--- a/firebolt/tests/test_c_data.mojo
+++ b/firebolt/tests/test_c_data.mojo
@@ -140,6 +140,140 @@ def test_list_array_from_pyarrow():
     )
 
 
+def test_schema_from_dtype():
+    var c_schema = CArrowSchema.from_dtype(int32)
+    var dtype = c_schema.to_dtype()
+    assert_equal(dtype, int32)
+
+    var c_schema_str = CArrowSchema.from_dtype(string)
+    var dtype_str = c_schema_str.to_dtype()
+    assert_equal(dtype_str, string)
+
+    var c_schema_bool = CArrowSchema.from_dtype(bool_)
+    var dtype_bool = c_schema_bool.to_dtype()
+    assert_equal(dtype_bool, bool_)
+
+    var c_schema_float64 = CArrowSchema.from_dtype(float64)
+    var dtype_float64 = c_schema_float64.to_dtype()
+    assert_equal(dtype_float64, float64)
+
+
+def test_schema_to_field():
+    var pa = Python.import_module("pyarrow")
+    var pyfield = pa.field("test_field", pa.int32(), nullable=True)
+    var c_schema = CArrowSchema.from_pyarrow(pyfield)
+    var field = c_schema.to_field()
+    assert_equal(field.name, "test_field")
+    assert_equal(field.dtype, int32)
+    assert_equal(field.nullable, True)
+
+    var pyfield_str = pa.field("string_field", pa.string(), nullable=False)
+    var c_schema_str = CArrowSchema.from_pyarrow(pyfield_str)
+    var field_str = c_schema_str.to_field()
+    assert_equal(field_str.name, "string_field")
+    assert_equal(field_str.dtype, string)
+    assert_equal(field_str.nullable, False)
+
+
+def test_arrow_array_stream():
+    var pa = Python.import_module("pyarrow")
+    var python = Python()
+    ref cpython = python.cpython()
+
+    var data = Python.dict(
+        col1=Python.list(1.0, 2.0, 3.0, 4.0, 5.0),
+        col2=Python.list("a", "b", "c", "d", "e"),
+    )
+    var pyschema = pa.schema(
+        python.list(
+            pa.field("col1", pa.int64()),
+            pa.field("col2", pa.string()),
+        )
+    )
+    var table = pa.table(data, schema=pyschema)
+
+    var array_stream = ArrowArrayStream.from_pyarrow(table, cpython)
+
+    var c_schema = array_stream.c_schema()
+    var schema = c_schema.to_dtype()
+    assert_equal(len(schema.fields), 2)
+    assert_equal(schema.fields[0].name, "col1")
+    assert_equal(schema.fields[0].dtype, int64)
+    assert_equal(schema.fields[1].name, "col2")
+    assert_equal(schema.fields[1].dtype, string)
+
+    var c_array = array_stream.c_next()
+    assert_equal(c_array.length, 5)
+    assert_equal(c_array.null_count, 0)
+
+    var array_data = c_array.to_array(schema)
+    assert_equal(array_data.length, 5)
+    assert_equal(len(array_data.children), 2)
+
+    var col1_array = array_data.children[0][].as_int64()
+    assert_equal(col1_array.unsafe_get(0), 1)
+    assert_equal(col1_array.unsafe_get(4), 5)
+
+    var col2_array = array_data.children[1][].as_string()
+    assert_equal(String(col2_array.unsafe_get(0)), "a")
+    assert_equal(String(col2_array.unsafe_get(4)), "e")
+
+
+def test_struct_dtype_conversion():
+    var pa = Python.import_module("pyarrow")
+
+    var struct_fields = Python.list(
+        Python.tuple("x", pa.int32()), Python.tuple("y", pa.float64())
+    )
+    var struct_type = pa.`struct`(struct_fields)
+    var c_schema = CArrowSchema.from_pyarrow(struct_type)
+    var dtype = c_schema.to_dtype()
+
+    assert_true(dtype.is_struct())
+    assert_equal(len(dtype.fields), 2)
+    assert_equal(dtype.fields[0].name, "x")
+    assert_equal(dtype.fields[0].dtype, int32)
+    assert_equal(dtype.fields[1].name, "y")
+    assert_equal(dtype.fields[1].dtype, float64)
+
+
+def test_list_dtype_conversion():
+    var pa = Python.import_module("pyarrow")
+
+    var list_type = pa.list_(pa.int32())
+    var c_schema = CArrowSchema.from_pyarrow(list_type)
+    var dtype = c_schema.to_dtype()
+
+    assert_true(dtype.is_list())
+    assert_equal(dtype.fields[0].dtype, int32)
+
+
+def test_numeric_dtypes():
+    var pa = Python.import_module("pyarrow")
+
+    var types_to_test = [
+        (pa.int8(), int8),
+        (pa.uint8(), uint8),
+        (pa.int16(), int16),
+        (pa.uint16(), uint16),
+        (pa.int32(), int32),
+        (pa.uint32(), uint32),
+        (pa.int64(), int64),
+        (pa.uint64(), uint64),
+        (pa.float32(), float32),
+        (pa.float64(), float64),
+    ]
+
+    for i in range(len(types_to_test)):
+        var type_pair = types_to_test[i]
+        var py_type = type_pair[0]
+        var expected_mojo_type = type_pair[1]
+
+        var c_schema = CArrowSchema.from_pyarrow(py_type)
+        var dtype = c_schema.to_dtype()
+        assert_equal(dtype, expected_mojo_type)
+
+
 # def test_schema_to_pyarrow():
 #     var pa = Python.import_module("pyarrow")
 


### PR DESCRIPTION
Add support for one of the PyCapsule interfaces provided by PyArrow. This will enable integration with python code to read Parquet files or other similar use cases.

Fix a couple of small bugs exposed by the new tests.