### PR TITLE
Fix .envrc to work with pixi

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,2 @@
-if has magic; then
-  eval "$(magic shell-hook)"
-fi
+watch_file pixi.lock
+eval "$(pixi shell-hook)"


### PR DESCRIPTION
As per https://pixi.sh/latest/integration/third_party/direnv/

With direnv installed changing the folder will automatically install the right mojo, python versions.