### PR TITLE
chore: port to mojo 2025112205

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ The codebase follows a strict ownership hierarchy (documented in `marrow/MEMORY.
 
 3. **Array Trait** - All typed arrays implement:
    - `fn take_data(deinit self) -> ArrayData` - Consumes self to create standalone ArrayData
-   - `fn as_data[self_origin](ref [self_origin]self) -> UnsafePointer[ArrayData]` - Read-only reference to wrapped ArrayData
+   - `fn as_data[self_origin](ref [self_origin]self) -> LegacyUnsafePointer[ArrayData]` - Read-only reference to wrapped ArrayData
 
 ### Key Abstractions
 

--- a/marrow/arrays/base.mojo
+++ b/marrow/arrays/base.mojo
@@ -5,17 +5,17 @@ from ..buffers import Buffer, Bitmap
 trait Array(Movable, Representable, Sized, Stringable, Writable):
     fn take_data(deinit self) -> ArrayData:
         """Construct an ArrayData by consuming self."""
-        pass
+        ...
 
     fn as_data[
         self_origin: ImmutOrigin
-    ](ref [self_origin]self) -> UnsafePointer[ArrayData, mut=False]:
+    ](ref [self_origin]self) -> LegacyUnsafePointer[ArrayData, mut=False]:
         """Return a read only reference to the ArrayData wrapped by self.
 
         Note that ideally the output type would be `ref [self_origin] ArrayData` but this is not supported yet.
         https://forum.modular.com/t/how-to-mark-a-trait-as-applying-to-not-register-passable/2265/6?u=mseritan
         """
-        pass
+        ...
 
 
 @fieldwise_init

--- a/marrow/arrays/nested.mojo
+++ b/marrow/arrays/nested.mojo
@@ -65,8 +65,8 @@ struct ListArray(Array):
 
     fn as_data[
         self_origin: ImmutOrigin
-    ](ref [self_origin]self) -> UnsafePointer[ArrayData, mut=False]:
-        return UnsafePointer(to=self.data)
+    ](ref [self_origin]self) -> LegacyUnsafePointer[ArrayData, mut=False]:
+        return LegacyUnsafePointer(to=self.data)
 
     fn take_data(deinit self) -> ArrayData:
         return self.data^
@@ -171,8 +171,8 @@ struct StructArray(Array):
 
     fn as_data[
         self_origin: ImmutOrigin
-    ](ref [self_origin]self) -> UnsafePointer[ArrayData, mut=False]:
-        return UnsafePointer(to=self.data)
+    ](ref [self_origin]self) -> LegacyUnsafePointer[ArrayData, mut=False]:
+        return LegacyUnsafePointer(to=self.data)
 
     fn write_to[W: Writer](self, mut writer: W):
         """

--- a/marrow/arrays/tests/test_base.mojo
+++ b/marrow/arrays/tests/test_base.mojo
@@ -1,6 +1,6 @@
 """Test the base module."""
 from testing import assert_true, assert_false, assert_equal, TestSuite
-from memory import UnsafePointer, ArcPointer
+from memory import LegacyUnsafePointer, ArcPointer
 from marrow.arrays.base import ArrayData
 from marrow.buffers import Buffer, Bitmap
 from marrow.dtypes import DType, int8, uint8, int64

--- a/marrow/dtypes.mojo
+++ b/marrow/dtypes.mojo
@@ -4,149 +4,147 @@ from sys import size_of
 # The following enum codes are copied from the C++ implementation of Arrow
 
 # A NULL type having no physical storage
-alias NA = 0
+comptime NA = 0
 
 # Boolean as 1 bit, LSB bit-packed ordering
-alias BOOL = 1
+comptime BOOL = 1
 
 # Unsigned 8-bit little-endian integer
-alias UINT8 = 2
+comptime UINT8 = 2
 
 # Signed 8-bit little-endian integer
-alias INT8 = 3
+comptime INT8 = 3
 
 # Unsigned 16-bit little-endian integer
-alias UINT16 = 4
+comptime UINT16 = 4
 
 # Signed 16-bit little-endian integer
-alias INT16 = 5
+comptime INT16 = 5
 
 # Unsigned 32-bit little-endian integer
-alias UINT32 = 6
+comptime UINT32 = 6
 
 # Signed 32-bit little-endian integer
-alias INT32 = 7
+comptime INT32 = 7
 
 # Unsigned 64-bit little-endian integer
-alias UINT64 = 8
+comptime UINT64 = 8
 
 # Signed 64-bit little-endian integer
-alias INT64 = 9
+comptime INT64 = 9
 
 # 2-byte floating point value
-alias FLOAT16 = 10
+comptime FLOAT16 = 10
 
 # 4-byte floating point value
-alias FLOAT32 = 11
+comptime FLOAT32 = 11
 
 # 8-byte floating point value
-alias FLOAT64 = 12
+comptime FLOAT64 = 12
 
 # UTF8 variable-length string as List<Char>
-alias STRING = 13
+comptime STRING = 13
 
 # Variable-length bytes (no guarantee of UTF8-ness)
-alias BINARY = 14
+comptime BINARY = 14
 
 # Fixed-size binary. Each value occupies the same number of bytes
-alias FIXED_SIZE_BINARY = 15
+comptime FIXED_SIZE_BINARY = 15
 
 # int32_t days since the UNIX epoch
-alias DATE32 = 16
+comptime DATE32 = 16
 
 # int64_t milliseconds since the UNIX epoch
-alias DATE64 = 17
+comptime DATE64 = 17
 
 # Exact timestamp encoded with int64 since UNIX epoch
 # Default unit millisecond
-alias TIMESTAMP = 18
+comptime TIMESTAMP = 18
 
 # Time as signed 32-bit integer, representing either seconds or
 # milliseconds since midnight
-alias TIME32 = 19
+comptime TIME32 = 19
 
 # Time as signed 64-bit integer, representing either microseconds or
 # nanoseconds since midnight
-alias TIME64 = 20
+comptime TIME64 = 20
 
 # YEAR_MONTH interval in SQL style
-alias INTERVAL_MONTHS = 21
+comptime INTERVAL_MONTHS = 21
 
 # DAY_TIME interval in SQL style
-alias INTERVAL_DAY_TIME = 22
+comptime INTERVAL_DAY_TIME = 22
 
 # Precision- and scale-based decimal type with 128 bits.
-alias DECIMAL128 = 23
+comptime DECIMAL128 = 23
 
 # Defined for backward-compatibility.
-alias DECIMAL = DECIMAL128
+comptime DECIMAL = DECIMAL128
 
 # Precision- and scale-based decimal type with 256 bits.
-alias DECIMAL256 = 24
+comptime DECIMAL256 = 24
 
 # A list of some logical data type
-alias LIST = 25
+comptime LIST = 25
 
 # Struct of logical types
-alias STRUCT = 26
+comptime STRUCT = 26
 
 # Sparse unions of logical types
-alias SPARSE_UNION = 27
+comptime SPARSE_UNION = 27
 
 # Dense unions of logical types
-alias DENSE_UNION = 28
+comptime DENSE_UNION = 28
 
 # Dictionary-encoded type, also called "categorical" or "factor"
 # in other programming languages. Holds the dictionary value
 # type but not the dictionary itself, which is part of the
 # ArrayData struct
-alias DICTIONARY = 29
+comptime DICTIONARY = 29
 
 # Map, a repeated struct logical type
-alias MAP = 30
+comptime MAP = 30
 
 # Custom data type, implemented by user
-alias EXTENSION = 31
+comptime EXTENSION = 31
 
 # Fixed size list of some logical type
-alias FIXED_SIZE_LIST = 32
+comptime FIXED_SIZE_LIST = 32
 
 # Measure of elapsed time in either seconds, milliseconds, microseconds
 # or nanoseconds.
-alias DURATION = 33
+comptime DURATION = 33
 
 # Like STRING, but with 64-bit offsets
-alias LARGE_STRING = 34
+comptime LARGE_STRING = 34
 
 # Like BINARY, but with 64-bit offsets
-alias LARGE_BINARY = 35
+comptime LARGE_BINARY = 35
 
 # Like LIST, but with 64-bit offsets
-alias LARGE_LIST = 36
+comptime LARGE_LIST = 36
 
 # Calendar interval type with three fields.
-alias INTERVAL_MONTH_DAY_NANO = 37
+comptime INTERVAL_MONTH_DAY_NANO = 37
 
 # Run-end encoded data.
-alias RUN_END_ENCODED = 38
+comptime RUN_END_ENCODED = 38
 
 # String (UTF8) view type with 4-byte prefix and inline small string
 # optimization
-alias STRING_VIEW = 39
+comptime STRING_VIEW = 39
 
 # Bytes view type with 4-byte prefix and inline small string optimization
-alias BINARY_VIEW = 40
+comptime BINARY_VIEW = 40
 
 # A list of some logical data type represented by offset and size.
-alias LIST_VIEW = 41
+comptime LIST_VIEW = 41
 
 # Like LIST_VIEW, but with 64-bit offsets and sizes
-alias LARGE_LIST_VIEW = 42
+comptime LARGE_LIST_VIEW = 42
 
 
-struct Field(
-    Copyable, EqualityComparable, Movable, Representable, Stringable, Writable
-):
+struct Field(Copyable, Equatable, Movable, Representable, Stringable, Writable):
     var name: String
     var dtype: DataType
     var nullable: Bool
@@ -198,7 +196,7 @@ struct Field(
 
 
 struct DataType(
-    Copyable, EqualityComparable, Movable, Representable, Stringable, Writable
+    Copyable, Equatable, Movable, Representable, Stringable, Writable
 ):
     var code: UInt8
     var native: DType
@@ -410,23 +408,23 @@ fn struct_(var *fields: Field) -> DataType:
     return DataType(code=STRUCT, fields=List(elements=fields^))
 
 
-alias null = DataType(code=NA)
-alias bool_ = DataType(code=BOOL, native=DType.bool)
-alias int8 = DataType(code=INT8, native=DType.int8)
-alias int16 = DataType(code=INT16, native=DType.int16)
-alias int32 = DataType(code=INT32, native=DType.int32)
-alias int64 = DataType(code=INT64, native=DType.int64)
-alias uint8 = DataType(code=UINT8, native=DType.uint8)
-alias uint16 = DataType(code=UINT16, native=DType.uint16)
-alias uint32 = DataType(code=UINT32, native=DType.uint32)
-alias uint64 = DataType(code=UINT64, native=DType.uint64)
-alias float16 = DataType(code=FLOAT16, native=DType.float16)
-alias float32 = DataType(code=FLOAT32, native=DType.float32)
-alias float64 = DataType(code=FLOAT64, native=DType.float64)
-alias string = DataType(code=STRING)
-alias binary = DataType(code=BINARY)
+comptime null = DataType(code=NA)
+comptime bool_ = DataType(code=BOOL, native=DType.bool)
+comptime int8 = DataType(code=INT8, native=DType.int8)
+comptime int16 = DataType(code=INT16, native=DType.int16)
+comptime int32 = DataType(code=INT32, native=DType.int32)
+comptime int64 = DataType(code=INT64, native=DType.int64)
+comptime uint8 = DataType(code=UINT8, native=DType.uint8)
+comptime uint16 = DataType(code=UINT16, native=DType.uint16)
+comptime uint32 = DataType(code=UINT32, native=DType.uint32)
+comptime uint64 = DataType(code=UINT64, native=DType.uint64)
+comptime float16 = DataType(code=FLOAT16, native=DType.float16)
+comptime float32 = DataType(code=FLOAT32, native=DType.float32)
+comptime float64 = DataType(code=FLOAT64, native=DType.float64)
+comptime string = DataType(code=STRING)
+comptime binary = DataType(code=BINARY)
 
-alias all_numeric_dtypes = [
+comptime all_numeric_dtypes = [
     int8,
     int16,
     int32,

--- a/marrow/module/arrays/primitive_api.mojo
+++ b/marrow/module/arrays/primitive_api.mojo
@@ -20,16 +20,17 @@ struct PrimitiveArray(Movable, Representable):
         return "PrimitiveArray"
 
     @staticmethod
-    fn __len__(self_ptr: UnsafePointer[Self]) -> PythonObject:
+    fn __len__(py_self: PythonObject) raises -> PythonObject:
         """Return the length of the underlying ArrayData."""
+        var self_ptr = py_self.downcast_value_ptr[Self]()
         return self_ptr[].data.length
 
     @staticmethod
     fn __getitem__(
-        self_ptr: UnsafePointer[Self], index: PythonObject
+        py_self: PythonObject, index: PythonObject
     ) raises -> PythonObject:
         """Access the element at the given index."""
-
+        var self_ptr = py_self.downcast_value_ptr[Self]()
         return primitive.Int64Array(self_ptr[].data.copy()).unsafe_get(
             Int(index)
         )

--- a/marrow/tests/test_buffers.mojo
+++ b/marrow/tests/test_buffers.mojo
@@ -4,7 +4,7 @@ from marrow.test_fixtures.arrays import assert_bitmap_set
 from marrow.buffers import *
 
 
-def is_aligned[T: AnyType](ptr: UnsafePointer[T], alignment: Int) -> Bool:
+def is_aligned[T: AnyType](ptr: LegacyUnsafePointer[T], alignment: Int) -> Bool:
     return (Int(ptr) % alignment) == 0
 
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -12,11 +12,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.12-py312hd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
@@ -24,9 +24,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-bootstrap_ha15bf96_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-h767d61c_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
@@ -40,10 +40,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.7.0.dev2025111005-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-0.25.7.0.dev2025111005-release.conda
-      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-0.25.7.0.dev2025111005-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.25.7.0.dev2025111005-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.1.0.dev2025112205-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-0.26.1.0.dev2025112205-release.conda
+      - conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-0.26.1.0.dev2025112205-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.26.1.0.dev2025112205-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
@@ -59,9 +59,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hfb55c3c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.4-h813ae00_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.6-h813ae00_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.2-py312h4c3975b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
@@ -69,34 +69,33 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
       - pypi: https://files.pythonhosted.org/packages/bb/1b/2168d6050e52ff1e6cefc61d600723870bf569cbf41d13db939c8cf97a16/pyarrow-20.0.0-cp312-cp312-manylinux_2_28_x86_64.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.0-pyh707e725_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.12-py312hd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-75.1-hfee45f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.5-hf598326_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.6-hf598326_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.3-haf25636_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-he5f378a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.0-h8adb53f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mblack-25.7.0.dev2025111005-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-0.25.7.0.dev2025111005-release.conda
-      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-0.25.7.0.dev2025111005-release.conda
-      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.25.7.0.dev2025111005-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mblack-26.1.0.dev2025112205-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-0.26.1.0.dev2025112205-release.conda
+      - conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-0.26.1.0.dev2025112205-release.conda
+      - conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.26.1.0.dev2025112205-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
@@ -112,9 +111,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312hd65ceae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.4-h382de68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.6-h382de68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.2-py312h4409184_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
@@ -177,18 +176,18 @@ packages:
   purls: []
   size: 125061
   timestamp: 1757437486465
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.10.5-hbd8a1cb_0.conda
-  sha256: 3b5ad78b8bb61b6cdc0978a6a99f8dfb2cc789a451378d054698441005ecbdb6
-  md5: f9e5fbc24009179e8b0409624691758a
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+  sha256: b986ba796d42c9d3265602bc038f6f5264095702dd546c14bc684e60c385e773
+  md5: f0991f0f84902f6b6009b4d2350a83aa
   depends:
   - __unix
   license: ISC
   purls: []
-  size: 155907
-  timestamp: 1759649036195
-- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.0-pyh707e725_0.conda
-  sha256: c6567ebc27c4c071a353acaf93eb82bb6d9a6961e40692a359045a89a61d02c0
-  md5: e76c4ba9e1837847679421b8d549b784
+  size: 152432
+  timestamp: 1762967197890
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh707e725_0.conda
+  sha256: 970b12fb186c3451eee9dd0f10235aeb75fb570b0e9dc83250673c2f0b196265
+  md5: 9ba00b39e03a0afb2b1cc0767d4c6175
   depends:
   - __unix
   - python >=3.10
@@ -196,8 +195,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/click?source=compressed-mapping
-  size: 91622
-  timestamp: 1758270534287
+  size: 92604
+  timestamp: 1763248639281
 - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
@@ -220,17 +219,17 @@ packages:
   purls: []
   size: 45767
   timestamp: 1761175217281
-- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
-  sha256: ce61f4f99401a4bd455b89909153b40b9c823276aefcbb06f2044618696009ca
-  md5: 72e42d28960d875c7654614f8b50939a
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
+  md5: 8e662bd460bda79b1ea39194e3c4c9ab
   depends:
-  - python >=3.9
+  - python >=3.10
   - typing_extensions >=4.6.0
   license: MIT and PSF-2.0
   purls:
-  - pkg:pypi/exceptiongroup?source=hash-mapping
-  size: 21284
-  timestamp: 1746947398083
+  - pkg:pypi/exceptiongroup?source=compressed-mapping
+  size: 21333
+  timestamp: 1763918099466
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
   sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
   md5: 8b189310083baabfb622af68fd9d3ae3
@@ -351,28 +350,27 @@ packages:
   purls: []
   size: 1155530
   timestamp: 1719463474401
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.44-h1aa0949_5.conda
-  sha256: dab1fbf65abb05d3f2ee49dff90d60eeb2e02039fcb561343c7cea5dea523585
-  md5: 511ed8935448c1875776b60ad3daf3a1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-bootstrap_ha15bf96_3.conda
+  sha256: 7dfdf5500318521827c590fbda0fce5d6bda1d15dfee11b677d420580d18ccc0
+  md5: 3036ca5b895b7f5146c5a25486234a68
   depends:
   - __glibc >=2.17,<3.0.a0
-  - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - binutils_impl_linux-64 2.44
+  - binutils_impl_linux-64 2.45
   license: GPL-3.0-only
   purls: []
-  size: 741516
-  timestamp: 1762674665675
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.5-hf598326_0.conda
-  sha256: cb441b85669eec99a593f59e6bb18c1d8a46d13eebadfc6a55f0b298109bf510
-  md5: fbfdbf6e554275d2661c4541f45fed53
+  size: 729222
+  timestamp: 1763768158810
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.6-hf598326_0.conda
+  sha256: 6c8d5c50f398035c39f118a6decf91b11d2461c88aef99f81e5c5de200d2a7fa
+  md5: 3ea79e55a64bff6c3cbd4588c89a527a
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 569449
-  timestamp: 1762258167196
+  size: 569823
+  timestamp: 1763470498512
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -398,31 +396,31 @@ packages:
   purls: []
   size: 107691
   timestamp: 1738479560845
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.1-hecca717_0.conda
-  sha256: da2080da8f0288b95dd86765c801c6e166c4619b910b11f9a8446fb852438dc2
-  md5: 4211416ecba1866fab0c6470986c22d6
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
+  sha256: 1e1b08f6211629cbc2efe7a5bca5953f8f6b3cae0eeb04ca4dacee1bd4e2db2f
+  md5: 8b09ae86839581147ef2e5c5e229d164
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   constrains:
-  - expat 2.7.1.*
+  - expat 2.7.3.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 74811
-  timestamp: 1752719572741
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.1-hec049ff_0.conda
-  sha256: 8fbb17a56f51e7113ed511c5787e0dec0d4b10ef9df921c4fd1cccca0458f648
-  md5: b1ca5f21335782f71a8bd69bdc093f67
+  size: 76643
+  timestamp: 1763549731408
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.3-haf25636_0.conda
+  sha256: fce22610ecc95e6d149e42a42fbc3cc9d9179bd4eb6232639a60f06e080eec98
+  md5: b79875dbb5b1db9a4a22a4520f918e1a
   depends:
   - __osx >=11.0
   constrains:
-  - expat 2.7.1.*
+  - expat 2.7.3.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 65971
-  timestamp: 1752719657566
+  size: 67800
+  timestamp: 1763549994166
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
   sha256: 25cbdfa65580cfab1b8d15ee90b4c9f1e0d72128f1661449c9a999d341377d54
   md5: 35f29eec58405aaf55e01cb470d8c26a
@@ -621,9 +619,9 @@ packages:
   purls: []
   size: 46438
   timestamp: 1727963202283
-- conda: https://conda.modular.com/max-nightly/noarch/mblack-25.7.0.dev2025111005-release.conda
+- conda: https://conda.modular.com/max-nightly/noarch/mblack-26.1.0.dev2025112205-release.conda
   noarch: python
-  sha256: 690a477f22afac88913ace2e43328c197c23b40b9de3e2cf521fc8b26e89df5d
+  sha256: 4e5b1c578a5635c38026fea110f771ce701bab5298398fc37a332e8295c81a7e
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -635,50 +633,50 @@ packages:
   - typing_extensions >=v4.12.2
   - python
   license: MIT
-  size: 138103
-  timestamp: 1762753130585
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-0.25.7.0.dev2025111005-release.conda
-  sha256: 024c5700d80f712cab95a0a863560708c6e886521425226af4dee7cd81011b8c
+  size: 138223
+  timestamp: 1763789073713
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-0.26.1.0.dev2025112205-release.conda
+  sha256: 3ce08c27c7029d08151f01968a273221056be44e2c53bafb16f1631596602ea5
   depends:
   - python >=3.10
-  - mojo-compiler ==0.25.7.0.dev2025111005 release
-  - mblack ==25.7.0.dev2025111005 release
+  - mojo-compiler ==0.26.1.0.dev2025112205 release
+  - mblack ==26.1.0.dev2025112205 release
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 88992504
-  timestamp: 1762753130585
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-0.25.7.0.dev2025111005-release.conda
-  sha256: 5c34272ea0dc6fcf37b7c8d9b236a3e47c199d01680686403747d6905a3e4018
+  size: 81494548
+  timestamp: 1763789073714
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-0.26.1.0.dev2025112205-release.conda
+  sha256: 2276cc177e5c6d8ff706a3650e1295f277861f1437f06580dac34822e4cd2138
   depends:
   - python >=3.10
-  - mojo-compiler ==0.25.7.0.dev2025111005 release
-  - mblack ==25.7.0.dev2025111005 release
+  - mojo-compiler ==0.26.1.0.dev2025112205 release
+  - mblack ==26.1.0.dev2025112205 release
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 75189907
-  timestamp: 1762753372397
-- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-0.25.7.0.dev2025111005-release.conda
-  sha256: 9c5e9bba2350079ab75ce35a3a7dcbd407b67e117d982346e841169a8626f6ed
+  size: 68310906
+  timestamp: 1763789115031
+- conda: https://conda.modular.com/max-nightly/linux-64/mojo-compiler-0.26.1.0.dev2025112205-release.conda
+  sha256: fcae6aa783d794996e664ab704285e7b2f6003667384cd31af85a28f1f4f3c1b
   depends:
-  - mojo-python ==0.25.7.0.dev2025111005 release
+  - mojo-python ==0.26.1.0.dev2025112205 release
   license: LicenseRef-Modular-Proprietary
-  size: 88583127
-  timestamp: 1762753130585
-- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-0.25.7.0.dev2025111005-release.conda
-  sha256: b14495d02df9a4c417b7dcda4ca7a507fd47e51f18ff7ef0c764882dffc2f73d
+  size: 77849968
+  timestamp: 1763789073713
+- conda: https://conda.modular.com/max-nightly/osx-arm64/mojo-compiler-0.26.1.0.dev2025112205-release.conda
+  sha256: df6c4d4f9c38641e038fc9e76b1699f6b39b4bc65a11419393f37a5559aa076a
   depends:
-  - mojo-python ==0.25.7.0.dev2025111005 release
+  - mojo-python ==0.26.1.0.dev2025112205 release
   license: LicenseRef-Modular-Proprietary
-  size: 63112123
-  timestamp: 1762753372397
-- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.25.7.0.dev2025111005-release.conda
+  size: 58737131
+  timestamp: 1763789115031
+- conda: https://conda.modular.com/max-nightly/noarch/mojo-python-0.26.1.0.dev2025112205-release.conda
   noarch: python
-  sha256: 3af1c24d1d5da3f8cb88e5ec77765c340573259824824f298c744eed8aa40ae3
+  sha256: 2394fcd34b0396539db923f5f1f5706e48806c812611477a741909bbea264792
   depends:
   - python
   license: LicenseRef-Modular-Proprietary
-  size: 24754
-  timestamp: 1762753130585
+  size: 24758
+  timestamp: 1763789073713
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06
@@ -829,7 +827,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytest?source=compressed-mapping
+  - pkg:pypi/pytest?source=hash-mapping
   size: 294852
   timestamp: 1762354779909
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_1_cpython.conda
@@ -973,25 +971,25 @@ packages:
   purls: []
   size: 252359
   timestamp: 1740379663071
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.4-h813ae00_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.6-h813ae00_0.conda
   noarch: python
-  sha256: 23121b3e5d6f0cfe8cf6600a2b1e63e4f8cdd3aa2ceee25625b98a3caa2d93e5
-  md5: a62b7614fdd1b448700d7e4078cc1b28
+  sha256: 2c811e3c15b343a7cf4f3d3985710d63d36310d7c21a2db4c00a42e0e3c9fc1a
+  md5: 406217e531c7261aa6ea8cba649693b4
   depends:
   - python
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   constrains:
   - __glibc >=2.17
   license: MIT
   purls:
-  - pkg:pypi/ruff?source=hash-mapping
-  size: 11120550
-  timestamp: 1762483239399
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.4-h382de68_0.conda
+  - pkg:pypi/ruff?source=compressed-mapping
+  size: 11216432
+  timestamp: 1763741549592
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.6-h382de68_0.conda
   noarch: python
-  sha256: a672c1310b844f32495d62a4db0d1fd0ac1cd154839425f0f3ff64c95c01356d
-  md5: 26b89c217a5f7c17ac8bd8082ec37a2a
+  sha256: 4af88350b75663fe6d7eeac0a93885d84044c1b8ae5c0f615a9499889b9e71e9
+  md5: 9146a375cf7c83d6e155f17af4154d67
   depends:
   - python
   - __osx >=11.0
@@ -1000,8 +998,8 @@ packages:
   license: MIT
   purls:
   - pkg:pypi/ruff?source=hash-mapping
-  size: 10067548
-  timestamp: 1762483365075
+  size: 10204867
+  timestamp: 1763741771088
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3
@@ -1014,29 +1012,31 @@ packages:
   - pkg:pypi/six?source=hash-mapping
   size: 18455
   timestamp: 1753199211006
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
-  sha256: a84ff687119e6d8752346d1d408d5cf360dee0badd487a472aa8ddedfdc219e1
-  md5: a0116df4f4ed05c303811a837d5b39d8
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
+  sha256: 1544760538a40bcd8ace2b1d8ebe3eb5807ac268641f8acdc18c69c5ebfeaf64
+  md5: 86bc20552bf46075e3d92b67f089172d
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.12,<2.0a0
   license: TCL
   license_family: BSD
   purls: []
-  size: 3285204
-  timestamp: 1748387766691
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
-  sha256: cb86c522576fa95c6db4c878849af0bccfd3264daf0cc40dd18e7f4a7bfced0e
-  md5: 7362396c170252e7b7b0c8fb37fe9c78
+  size: 3284905
+  timestamp: 1763054914403
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_3.conda
+  sha256: ad0c67cb03c163a109820dc9ecf77faf6ec7150e942d1e8bb13e5d39dc058ab7
+  md5: a73d54a5abba6543cb2f0af1bfbd6851
   depends:
   - __osx >=11.0
   - libzlib >=1.3.1,<2.0a0
   license: TCL
   license_family: BSD
   purls: []
-  size: 3125538
-  timestamp: 1748388189063
+  size: 3125484
+  timestamp: 1763055028377
 - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
   sha256: cb77c660b646c00a48ef942a9e1721ee46e90230c7c570cdeb5a893b5cce9bff
   md5: d2732eb636c264dc9aa4cbee404b1a53
@@ -1146,16 +1146,3 @@ packages:
   - pkg:pypi/zipp?source=hash-mapping
   size: 22963
   timestamp: 1749421737203
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-  sha256: a4166e3d8ff4e35932510aaff7aa90772f84b4d07e9f6f83c614cba7ceefe0eb
-  md5: 6432cb5d4ac0046c3ac0a8a0f95842f9
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - libzlib >=1.3.1,<2.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 567578
-  timestamp: 1742433379869


### PR DESCRIPTION
Use the LegacyUnsafePointer, migrating to the new UnsafePointer requires more work. Some of the ffi functions also needed some work.

Also use comptime instead of alias.