### PR TITLE
fix(kernels): cast global_idx.x to Int to fix similarity type error

### DIFF
--- a/marrow/kernels/similarity.mojo
+++ b/marrow/kernels/similarity.mojo
@@ -97,9 +97,9 @@ def _cosine_similarity_gpu_kernel[
     dim: Int,
 ):
     """GPU kernel: each thread computes one vector's cosine similarity."""
-    var tid = global_idx.x
-    if tid < UInt(n_vectors):
-        var offset = Int(tid) * dim
+    var tid = Int(global_idx.x)
+    if tid < n_vectors:
+        var offset = tid * dim
         var dot = Scalar[dtype](0)
         var norm_v = Scalar[dtype](0)
         var norm_q = Scalar[dtype](0)


### PR DESCRIPTION
On recent nightly MAX builds, global_idx.x returns Int instead of UInt. The previous `tid < UInt(n_vectors)` comparison (Int < UInt) is rejected by the compiler. Cast at assignment with Int(global_idx.x) and drop the redundant Int(tid) cast, so the code compiles on both stable and nightly.

Closes #86 
Closes https://github.com/JRedrupp/bison/issues/587