### PR TITLE
fix(builders): amortize StringBuilder.reserve_bytes growth

### DIFF
--- a/marrow/builders.mojo
+++ b/marrow/builders.mojo
@@ -548,8 +548,11 @@ struct StringBuilder(Builder, Sized):
 
     def reserve_bytes(mut self, additional: Int) raises:
         """Pre-allocate space in the byte data buffer."""
-        var needed = len(self._values) + additional
-        self._values.resize[DType.uint8](needed)
+        var used = Int(self._offsets.unsafe_get[DType.uint32](self._length))
+        var needed = used + additional
+        if needed > len(self._values):
+            var new_cap = max(len(self._values) * 2, needed)
+            self._values.resize[DType.uint8](new_cap)
 
     @always_inline
     def unsafe_append[origin: Origin](mut self, s: StringSlice[origin]):

--- a/marrow/tests/test_arrays.mojo
+++ b/marrow/tests/test_arrays.mojo
@@ -318,6 +318,18 @@ def test_string_builder() raises:
     assert_equal(frozen[1], "world")
 
 
+def test_string_builder_amortized() raises:
+    # Append many strings without pre-allocated bytes capacity.
+    # Exercises amortized reserve_bytes growth (previously O(N²)).
+    var a = StringBuilder()
+    for i in range(100):
+        a.append(String(i))
+    var frozen = a.finish()
+    assert_equal(len(frozen), 100)
+    for i in range(100):
+        assert_equal(frozen[i], String(i))
+
+
 def test_list_bool_array() raises:
     var bool_b = BoolBuilder(3)
     bool_b.append(True)


### PR DESCRIPTION
## Problem

`StringBuilder.append` was O(N²) for sequential appends. `reserve_bytes` was using `len(self._values)` (allocated bytes) as the write cursor, so every append computed `allocated + additional` as the new size and triggered an unconditional `memcpy` reallocation — even when there was plenty of free capacity.

## Fix

Read the actual write cursor from `_offsets[_length]`, skip the resize when capacity is sufficient, and double the buffer when growing — matching the amortized pattern already in `PrimitiveBuilder.reserve`.

## Test

Added `test_string_builder_amortized`: 100 sequential appends without pre-allocated byte capacity.

Fixes upstream bug reported in JRedrupp/bison#637.
Should speedup the benchmarks as seen in Bison: https://jredrupp.github.io/bison/