### PR TITLE
perf(kernels): hoist dtype resolution out of groupby per-row loop

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,13 +28,8 @@ jobs:
           frozen: true
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-          frozen: true
-      - name: Run benchmarks
-        run: |
-          mkdir -p .benchmarks
-          pixi run -e bench pytest --benchmark -v --benchmark-json .benchmarks/results.json
-      - name: Store benchmark results
-        uses: benchmark-action/github-action-benchmark@v1
+
+      - uses: actions/cache@v4
         with:
           path: .pixi/envs/bench/**/.mojo_cache
           key: mojo-cache-bench-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -28,8 +28,13 @@ jobs:
           frozen: true
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-
-      - uses: actions/cache@v4
+          frozen: true
+      - name: Run benchmarks
+        run: |
+          mkdir -p .benchmarks
+          pixi run -e bench pytest --benchmark -v --benchmark-json .benchmarks/results.json
+      - name: Store benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
         with:
           path: .pixi/envs/bench/**/.mojo_cache
           key: mojo-cache-bench-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}

--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,7 @@ docs/_freeze/
 kgen.trace.*
 package/
 .test_runners/
+.benchmarks/
 
 # Benchmark scratch output (transformed into results/ by run_benchmarks.sh)
 .benchmarks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 - **`PyUnicode_AsUTF8AndSize` return type** (`python/arrays.mojo`): `PyUnicode_AsUTF8AndSize` now returns `StringSlice[ImmutAnyOrigin]` directly; removed the stale `.value()` unwrap that caused a compile error against newer Mojo stdlib.
 
+- **ASAP destruction UAF in `bench_groupby`** (`marrow/kernels/tests/bench_groupby.mojo`): Added `keep(keys)` / `keep(vals)` after `b.iter[call]()` so the `@parameter` closure's captured arrays stay live for the duration of the benchmark loop. Without them, Mojo's ASAP destruction freed `keys`/`vals` before the iteration completed, corrupting the heap and crashing the subsequent `SwissHashTable` allocation. Re-enables the `bench-mojo` CI job.
+
 ## [Unreleased] — 2026-03-18
 
 ### Features

--- a/marrow/kernels/groupby.mojo
+++ b/marrow/kernels/groupby.mojo
@@ -247,29 +247,53 @@ struct AggregateFunction(Copyable, Movable):
         var dt = input_col.dtype()
 
         if dt == bool_:
-            _add_batch_bool(self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_bool(
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == int8:
-            _add_batch_typed[Int8Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[Int8Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == int16:
-            _add_batch_typed[Int16Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[Int16Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == int32:
-            _add_batch_typed[Int32Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[Int32Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == int64:
-            _add_batch_typed[Int64Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[Int64Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == uint8:
-            _add_batch_typed[UInt8Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[UInt8Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == uint16:
-            _add_batch_typed[UInt16Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[UInt16Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == uint32:
-            _add_batch_typed[UInt32Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[UInt32Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == uint64:
-            _add_batch_typed[UInt64Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[UInt64Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == float16:
-            _add_batch_typed[Float16Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[Float16Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == float32:
-            _add_batch_typed[Float32Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[Float32Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         elif dt == float64:
-            _add_batch_typed[Float64Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+            _add_batch_typed[Float64Type](
+                self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap
+            )
         else:
             raise Error("unsupported dtype for aggregation: ", dt)
 

--- a/marrow/kernels/groupby.mojo
+++ b/marrow/kernels/groupby.mojo
@@ -122,6 +122,76 @@ def _read_as_float64(col: AnyArray, row: Int) raises -> Float64:
     raise Error("unsupported dtype for aggregation: ", col.dtype())
 
 
+def _add_batch_typed[
+    T: PrimitiveType
+](
+    name: String,
+    mut val_ptr: PrimitiveBuilder[Float64Type],
+    mut cnt_ptr: PrimitiveBuilder[Int64Type],
+    group_ids: PrimitiveArray[UInt32Type],
+    input_col: AnyArray,
+    has_bitmap: Bool,
+) raises:
+    """Type-specialized inner loop for add_batch.
+
+    Resolves the typed array once, then iterates without per-row dtype
+    dispatch.
+    """
+    var n = len(group_ids)
+    ref arr = input_col.as_primitive[T]()
+    for i in range(n):
+        if has_bitmap and not input_col.is_valid(i):
+            continue
+        var g = Int(group_ids.unsafe_get(i))
+        var cnt = Int(cnt_ptr.unsafe_get(g))
+        if name == "count":
+            cnt_ptr.unsafe_set(g, Scalar[int64.native](cnt + 1))
+            continue
+        var val = Float64(arr.unsafe_get(i))
+        var cur = Float64(val_ptr.unsafe_get(g))
+        if name == "sum" or name == "mean":
+            val_ptr.unsafe_set(g, Scalar[float64.native](cur + val))
+        elif name == "min":
+            if cnt == 0 or val < cur:
+                val_ptr.unsafe_set(g, Scalar[float64.native](val))
+        elif name == "max":
+            if cnt == 0 or val > cur:
+                val_ptr.unsafe_set(g, Scalar[float64.native](val))
+        cnt_ptr.unsafe_set(g, Scalar[int64.native](cnt + 1))
+
+
+def _add_batch_bool(
+    name: String,
+    mut val_ptr: PrimitiveBuilder[Float64Type],
+    mut cnt_ptr: PrimitiveBuilder[Int64Type],
+    group_ids: PrimitiveArray[UInt32Type],
+    input_col: AnyArray,
+    has_bitmap: Bool,
+) raises:
+    """Bool-specialized inner loop for add_batch."""
+    var n = len(group_ids)
+    ref arr = input_col.as_bool()
+    for i in range(n):
+        if has_bitmap and not input_col.is_valid(i):
+            continue
+        var g = Int(group_ids.unsafe_get(i))
+        var cnt = Int(cnt_ptr.unsafe_get(g))
+        if name == "count":
+            cnt_ptr.unsafe_set(g, Scalar[int64.native](cnt + 1))
+            continue
+        var val = Float64(arr[i].value())
+        var cur = Float64(val_ptr.unsafe_get(g))
+        if name == "sum" or name == "mean":
+            val_ptr.unsafe_set(g, Scalar[float64.native](cur + val))
+        elif name == "min":
+            if cnt == 0 or val < cur:
+                val_ptr.unsafe_set(g, Scalar[float64.native](val))
+        elif name == "max":
+            if cnt == 0 or val > cur:
+                val_ptr.unsafe_set(g, Scalar[float64.native](val))
+        cnt_ptr.unsafe_set(g, Scalar[int64.native](cnt + 1))
+
+
 struct AggregateFunction(Copyable, Movable):
     """Logic for one aggregation, operating on ``AggregateState``.
 
@@ -165,36 +235,43 @@ struct AggregateFunction(Copyable, Movable):
         group_ids: PrimitiveArray[UInt32Type],
         input_col: AnyArray,
     ) raises:
-        """Scatter-update: single O(N) pass over the batch."""
-        var n = len(group_ids)
+        """Scatter-update: single O(N) pass over the batch.
+
+        Dtype is resolved once before the loop and dispatched to a
+        type-specialized helper, avoiding per-row Variant construction
+        and comparison overhead.
+        """
         var has_bitmap = input_col.null_count() > 0
         ref val_ptr = self.values.builder.as_primitive[Float64Type]()
         ref cnt_ptr = self.counts.builder.as_primitive[Int64Type]()
+        var dt = input_col.dtype()
 
-        for i in range(n):
-            if has_bitmap and not input_col.is_valid(i):
-                continue
-
-            var g = Int(group_ids.unsafe_get(i))
-            var cnt = Int(cnt_ptr.unsafe_get(g))
-
-            if self.name == "count":
-                cnt_ptr.unsafe_set(g, Scalar[int64.native](cnt + 1))
-                continue
-
-            var val = _read_as_float64(input_col, i)
-            var cur = Float64(val_ptr.unsafe_get(g))
-
-            if self.name == "sum" or self.name == "mean":
-                val_ptr.unsafe_set(g, Scalar[float64.native](cur + val))
-            elif self.name == "min":
-                if cnt == 0 or val < cur:
-                    val_ptr.unsafe_set(g, Scalar[float64.native](val))
-            elif self.name == "max":
-                if cnt == 0 or val > cur:
-                    val_ptr.unsafe_set(g, Scalar[float64.native](val))
-
-            cnt_ptr.unsafe_set(g, Scalar[int64.native](cnt + 1))
+        if dt == bool_:
+            _add_batch_bool(self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == int8:
+            _add_batch_typed[Int8Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == int16:
+            _add_batch_typed[Int16Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == int32:
+            _add_batch_typed[Int32Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == int64:
+            _add_batch_typed[Int64Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == uint8:
+            _add_batch_typed[UInt8Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == uint16:
+            _add_batch_typed[UInt16Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == uint32:
+            _add_batch_typed[UInt32Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == uint64:
+            _add_batch_typed[UInt64Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == float16:
+            _add_batch_typed[Float16Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == float32:
+            _add_batch_typed[Float32Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        elif dt == float64:
+            _add_batch_typed[Float64Type](self.name, val_ptr, cnt_ptr, group_ids, input_col, has_bitmap)
+        else:
+            raise Error("unsupported dtype for aggregation: ", dt)
 
     def finish(
         mut self, col_name: String, num_groups: Int

--- a/marrow/kernels/tests/bench_groupby.mojo
+++ b/marrow/kernels/tests/bench_groupby.mojo
@@ -1,0 +1,104 @@
+"""Benchmarks for the groupby kernel.
+
+Run with:
+    pixi run pytest marrow/kernels/tests/bench_groupby.mojo --benchmark
+"""
+
+from std.benchmark import BenchMetric, keep
+
+from marrow.arrays import AnyArray
+from marrow.builders import PrimitiveBuilder
+from marrow.dtypes import int32, float64, Int32Type, Float64Type
+from marrow.kernels.groupby import groupby
+from marrow.testing import BenchSuite, Benchmark
+
+
+def _make_keys(n: Int, num_groups: Int) raises -> AnyArray:
+    var b = PrimitiveBuilder[Int32Type](n)
+    for i in range(n):
+        b.append(Scalar[int32.native](i % num_groups))
+    return AnyArray(b.finish())
+
+
+def _make_vals(n: Int) raises -> List[AnyArray]:
+    var b = PrimitiveBuilder[Float64Type](n)
+    for i in range(n):
+        b.append(Scalar[float64.native](Float64(i)))
+    var vals = List[AnyArray]()
+    vals.append(AnyArray(b.finish()))
+    return vals^
+
+
+def _aggs(s: String) -> List[String]:
+    var a = List[String]()
+    a.append(s)
+    return a^
+
+
+# ---------------------------------------------------------------------------
+# groupby sum
+# ---------------------------------------------------------------------------
+
+
+def _bench_groupby_sum(mut b: Benchmark, n: Int) raises:
+    var keys = _make_keys(n, 10)
+    var vals = _make_vals(n)
+    b.throughput(BenchMetric.elements, n)
+
+    @always_inline
+    @parameter
+    def call() raises:
+        keep(groupby(keys, vals, _aggs("sum")))
+
+    b.iter[call]()
+
+
+def bench_groupby_sum_10k(mut b: Benchmark) raises:
+    _bench_groupby_sum(b, 10_000)
+
+
+def bench_groupby_sum_100k(mut b: Benchmark) raises:
+    _bench_groupby_sum(b, 100_000)
+
+
+def bench_groupby_sum_1m(mut b: Benchmark) raises:
+    _bench_groupby_sum(b, 1_000_000)
+
+
+# ---------------------------------------------------------------------------
+# groupby min / max / mean — 100K rows
+# ---------------------------------------------------------------------------
+
+
+def _bench_groupby_agg(mut b: Benchmark, agg: String, n: Int) raises:
+    var keys = _make_keys(n, 10)
+    var vals = _make_vals(n)
+    b.throughput(BenchMetric.elements, n)
+
+    @always_inline
+    @parameter
+    def call() raises:
+        keep(groupby(keys, vals, _aggs(agg)))
+
+    b.iter[call]()
+
+
+def bench_groupby_min_100k(mut b: Benchmark) raises:
+    _bench_groupby_agg(b, "min", 100_000)
+
+
+def bench_groupby_max_100k(mut b: Benchmark) raises:
+    _bench_groupby_agg(b, "max", 100_000)
+
+
+def bench_groupby_mean_100k(mut b: Benchmark) raises:
+    _bench_groupby_agg(b, "mean", 100_000)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() raises:
+    BenchSuite.run[__functions_in_module()]()

--- a/marrow/kernels/tests/bench_groupby.mojo
+++ b/marrow/kernels/tests/bench_groupby.mojo
@@ -51,6 +51,8 @@ def _bench_groupby_sum(mut b: Benchmark, n: Int) raises:
         keep(groupby(keys, vals, _aggs("sum")))
 
     b.iter[call]()
+    keep(keys)
+    keep(vals)
 
 
 def bench_groupby_sum_10k(mut b: Benchmark) raises:
@@ -81,6 +83,8 @@ def _bench_groupby_agg(mut b: Benchmark, agg: String, n: Int) raises:
         keep(groupby(keys, vals, _aggs(agg)))
 
     b.iter[call]()
+    keep(keys)
+    keep(vals)
 
 
 def bench_groupby_min_100k(mut b: Benchmark) raises:


### PR DESCRIPTION
The groupby `add_batch` loop was calling `_read_as_float64(input_col, i)` per row, which re-resolves the column dtype (Variant alloc + 18-arm comparison + dealloc) on every iteration - even though it's constant for the entire batch. Profiling showed this accounted for ~41% of `groupby_sum` wall time.

This moves the dtype dispatch outside the loop and calls into type-specialized helpers instead, so the typed array is resolved once and the inner loop operates directly on it.

Blocked on #96 to get tests compiling again - will pull out of draft.

Groupby Benchmark: https://jredrupp.github.io/bison/

Closes https://github.com/JRedrupp/bison/issues/699