### PR TITLE
ci: cache mojo compiler artifacts and reorganize CI workflows

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,15 +24,14 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           frozen: true
+          environments: bench
       - uses: actions/cache@v4
         with:
-          path: .pixi/envs/default/**/.mojo_cache
-          key: mojo-cache-default-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
-          restore-keys: mojo-cache-default-${{ runner.os }}-
+          path: .pixi/envs/bench/**/.mojo_cache
+          key: mojo-cache-bench-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
+          restore-keys: mojo-cache-bench-${{ runner.os }}-
       - name: Run benchmarks
-        run: |
-          mkdir -p .benchmarks
-          pixi run pytest --benchmark -v --benchmark-json .benchmarks/results.json
+        run: pixi run -e bench bench --no-gpu
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -5,42 +5,27 @@ on:
     branches: [main]
   pull_request:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
-  bench-mojo:
-    if: false  # Temporarily disabled: hashtable benchmarks crash at -O3 (Mojo compiler bug)
+  bench-linux-x86_64:
+    name: bench (linux, x86_64)
     runs-on: ubuntu-latest
     env:
       MODULAR_HOME: "/home/runner/.modular"
       FORCE_COLOR: "1"
       PYTEST_ADDOPTS: "--color=yes"
     steps:
-      - uses: actions/checkout@v4
-      - uses: prefix-dev/setup-pixi@v0.9.4
-        with:
-          cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-          frozen: true
-          environments: bench
-      - uses: actions/cache@v4
-        with:
-          path: .pixi/envs/bench/**/.mojo_cache
-          key: mojo-cache-bench-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
-          restore-keys: mojo-cache-bench-${{ runner.os }}-
-      - name: Run benchmarks
-        run: pixi run -e bench bench --no-gpu
-      - name: Store benchmark results
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Mojo Kernel Benchmarks
-          tool: pytest
-          output-file-path: .benchmarks/results.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          comment-on-alert: true
-          alert-threshold: "130%"
-          fail-on-alert: false
-          benchmark-data-dir-path: dev/bench
+    - name: Checkout repo
+      uses: actions/checkout@v4
+    - uses: prefix-dev/setup-pixi@v0.9.4
+      with:
+        cache: true
+        cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        frozen: true
+        environments: bench
+    - uses: actions/cache@v4
+      with:
+        path: .pixi/envs/bench/**/.mojo_cache
+        key: mojo-cache-bench-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
+        restore-keys: mojo-cache-bench-${{ runner.os }}-
+    - name: benchmarks
+      run: pixi run -e bench bench --no-gpu

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -24,6 +24,11 @@ jobs:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
           frozen: true
+      - uses: actions/cache@v4
+        with:
+          path: .pixi/envs/default/**/.mojo_cache
+          key: mojo-cache-default-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
+          restore-keys: mojo-cache-default-${{ runner.os }}-
       - name: Run benchmarks
         run: |
           mkdir -p .benchmarks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ jobs:
       with:
         cache: true
         frozen: true
+    - uses: actions/cache@v4
+      with:
+        path: .pixi/envs/default/**/.mojo_cache
+        key: mojo-cache-default-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
+        restore-keys: mojo-cache-default-${{ runner.os }}-
     - name: Build mojopkg
       run: pixi run package
     - name: Build conda package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,11 @@ jobs:
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         frozen: true
         environments: dev
+    - uses: actions/cache@v4
+      with:
+        path: .pixi/envs/dev/**/.mojo_cache
+        key: mojo-cache-dev-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
+        restore-keys: mojo-cache-dev-${{ runner.os }}-
     - name: tests
       run: |
         pixi run -e dev test_parallel --no-gpu
@@ -45,6 +50,11 @@ jobs:
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         frozen: true
         environments: dev
+    - uses: actions/cache@v4
+      with:
+        path: .pixi/envs/dev/**/.mojo_cache
+        key: mojo-cache-dev-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
+        restore-keys: mojo-cache-dev-${{ runner.os }}-
     - name: tests
       run: |
         pixi run -e dev test_parallel --no-gpu
@@ -86,6 +96,11 @@ jobs:
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         frozen: true
         environments: asan
+    - uses: actions/cache@v4
+      with:
+        path: .pixi/envs/asan/**/.mojo_cache
+        key: mojo-cache-asan-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
+        restore-keys: mojo-cache-asan-${{ runner.os }}-
     - name: asan tests
       run: pixi run -e asan test_mojo_asan_parallel --no-gpu --no-python
 
@@ -106,5 +121,10 @@ jobs:
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         frozen: true
         environments: asan
+    - uses: actions/cache@v4
+      with:
+        path: .pixi/envs/asan/**/.mojo_cache
+        key: mojo-cache-asan-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
+        restore-keys: mojo-cache-asan-${{ runner.os }}-
     - name: asan tests
       run: pixi run -e asan test_mojo_asan_parallel --no-gpu --no-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,10 @@ jobs:
     - name: benchmarks
       run: pixi run -e bench bench --no-gpu
 
+  # TODO: re-enable once x86_64 ASAN compilation is fast enough
   asan-linux-x86_64:
     name: asan (linux, x86_64)
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,11 @@ jobs:
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         frozen: true
         environments: bench
+    - uses: actions/cache@v4
+      with:
+        path: .pixi/envs/bench/**/.mojo_cache
+        key: mojo-cache-bench-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
+        restore-keys: mojo-cache-bench-${{ runner.os }}-
     - name: benchmarks
       run: pixi run -e bench bench --no-gpu
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,13 +69,10 @@ jobs:
     - name: benchmarks
       run: pixi run -e bench bench --no-gpu
 
-  # TODO: re-enable once ASAN builds are fast enough
-  # asan-linux-x86_64:
-  asan-linux-x86_64-disabled:
+  asan-linux-x86_64:
     name: asan (linux, x86_64)
-    if: false
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       MODULAR_HOME: "/home/runner/.modular"
       FORCE_COLOR: "1"
@@ -90,4 +87,24 @@ jobs:
         frozen: true
         environments: asan
     - name: asan tests
-      run: pixi run -e asan test_mojo_asan --no-gpu --no-python
+      run: pixi run -e asan test_mojo_asan_parallel --no-gpu --no-python
+
+  asan-macos-arm64:
+    name: asan (macos, arm64)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    env:
+      MODULAR_HOME: "/Users/runner/.modular"
+      FORCE_COLOR: "1"
+      PYTEST_ADDOPTS: "--color=yes"
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - uses: prefix-dev/setup-pixi@v0.9.4
+      with:
+        cache: true
+        cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        frozen: true
+        environments: asan
+    - name: asan tests
+      run: pixi run -e asan test_mojo_asan_parallel --no-gpu --no-python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,30 +60,6 @@ jobs:
         pixi run -e dev test_parallel --no-gpu
         pixi run package
 
-  bench-linux-x86_64:
-    name: bench (linux, x86_64)
-    runs-on: ubuntu-latest
-    env:
-      MODULAR_HOME: "/home/runner/.modular"
-      FORCE_COLOR: "1"
-      PYTEST_ADDOPTS: "--color=yes"
-    steps:
-    - name: Checkout repo
-      uses: actions/checkout@v2
-    - uses: prefix-dev/setup-pixi@v0.9.4
-      with:
-        cache: true
-        cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-        frozen: true
-        environments: bench
-    - uses: actions/cache@v4
-      with:
-        path: .pixi/envs/bench/**/.mojo_cache
-        key: mojo-cache-bench-${{ runner.os }}-${{ hashFiles('pixi.lock', '**/*.mojo') }}
-        restore-keys: mojo-cache-bench-${{ runner.os }}-
-    - name: benchmarks
-      run: pixi run -e bench bench --no-gpu
-
   # TODO: re-enable once x86_64 ASAN compilation is fast enough
   asan-linux-x86_64:
     name: asan (linux, x86_64)


### PR DESCRIPTION
## Summary
- Cache Mojo compiler artifacts (`.mojo_cache`) between CI runs using `actions/cache@v4`, reducing warm build times from ~4-6 min to ~30-60s
- Re-enable macOS arm64 ASAN job with parallel execution
- Temporarily disable x86_64 ASAN job (compilation too slow on Linux)
- Move bench job from `test.yml` to `bench.yml` and re-enable it
- Remove unused `benchmark-action` integration
- Rename test workflow to "Tests"

## Cache details
The Mojo compiler caches compilation artifacts at `.pixi/envs/{env}/share/max/cache/.mojo_cache/` (~247 MB). `setup-pixi` saves its cache before tests run, so these runtime-populated artifacts were never preserved. Adding `actions/cache@v4` after `setup-pixi` captures them at end-of-job.

Measured locally (Mac arm64): 14x speedup for Mojo tests (65s → 4.5s), 13x for `python/marrow.so` (39s → 3s).