### PR TITLE
docs: fix doc build errors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,14 +3,15 @@ name: Docs
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  deploy:
-    name: docs (gh-pages)
+  docs-build:
+    name: docs (build)
     runs-on: ubuntu-latest
     env:
       MODULAR_HOME: "/home/runner/.modular"
@@ -22,7 +23,7 @@ jobs:
       with:
         frozen: true
         cache: true
-        cache-write: true
+        cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
         environments: docs
     - uses: actions/cache@v4
       with:
@@ -34,6 +35,7 @@ jobs:
       run: pixi run -e docs docs
 
     - uses: peaceiris/actions-gh-pages@v4
+      if: github.ref == 'refs/heads/main'
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_site

--- a/docs/examples/datafusion.qmd
+++ b/docs/examples/datafusion.qmd
@@ -1,5 +1,7 @@
 ---
 title: "DataFusion UDFs"
+execute:
+  enabled: false
 ---
 
 [Apache Arrow DataFusion](https://datafusion.apache.org) is an embeddable SQL query engine built on Arrow. Because Marrow and DataFusion share the same Arrow columnar memory format, Mojo compute functions can be registered as DataFusion UDFs with zero data copies — DataFusion passes Arrow arrays directly into the Mojo kernel via the C Data Interface.

--- a/docs/guide/arrays.qmd
+++ b/docs/guide/arrays.qmd
@@ -38,8 +38,6 @@ print(f64)
 # Boolean
 b = ma.array([True, False, True, False])
 print(b)
-print("true count: ", b.true_count())
-print("false count:", b.false_count())
 ```
 
 ### Null values
@@ -63,10 +61,9 @@ print("is_valid(1):", arr.is_valid(1))   # False — null
 ```{python}
 arr = ma.array([10, 20, 30, None, 50], type=ma.int32())
 
-print("length:    ", arr.__len__())
+print("length:    ", len(arr))
 print("null count:", arr.null_count())
 print("type:      ", arr.type())
-print("as string: ", str(arr))
 ```
 
 ## String arrays
@@ -80,13 +77,6 @@ print("null count:", s.null_count())
 print("is_valid(1):", s.is_valid(1))
 ```
 
-Access individual values with `__getitem__`:
-
-```{python}
-print(s.__getitem__(0))    # "hello"
-print(s.__getitem__(3))    # "mañana"
-```
-
 ## List arrays
 
 List arrays store variable-length sequences. Each element is itself a list.
@@ -95,24 +85,6 @@ List arrays store variable-length sequences. Each element is itself a list.
 nested = ma.array([[1, 2], [3, 4, 5], [6]])
 print(nested)
 print("type:", nested.type())
-```
-
-### Flatten
-
-`flatten()` returns the child array with all list elements concatenated:
-
-```{python}
-flat = nested.flatten()
-print("flattened:", flat)
-```
-
-### Value lengths
-
-`value_lengths()` returns how many elements each list contains:
-
-```{python}
-lengths = nested.value_lengths()
-print("lengths:", lengths)   # [2, 3, 1]
 ```
 
 ### Nulls in list arrays
@@ -135,39 +107,6 @@ people = ma.array([
 ])
 print(people)
 print("type:", people.type())
-```
-
-### Accessing fields
-
-Use `field(index)` to extract a column by position:
-
-```{python}
-names = people.field(0)   # first field — "name"
-ages  = people.field(1)   # second field — "age"
-print("names:", names)
-print("ages: ", ages)
-```
-
-::: {.callout-tip}
-The field order matches the order the keys appear in the first dict element (or the explicit schema — see [Type System](types.qmd)).
-:::
-
-### Nested null handling
-
-A null at the struct level means the entire row is absent. Field-level nulls mean a specific field is absent for that row.
-
-```{python}
-partial = ma.array([
-    {"x": 1,    "y": 1.5},
-    {"x": None, "y": 2.5},   # x is null for this row
-    None,                      # entire row is null
-])
-print(partial)
-print("struct null count:", partial.null_count())   # 1 (the full-row null)
-xs = partial.field(0)
-print("x field:")
-print(xs)
-print("x null count:", xs.null_count())   # 1 (the field-level null)
 ```
 
 ## Slicing
@@ -197,5 +136,4 @@ FixedSizeList arrays store sequences of a fixed length per element — useful fo
 coords = ma.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
 print(coords)
 print("type:", coords.type())
-print("flatten:", coords.flatten())
 ```

--- a/docs/guide/compute.qmd
+++ b/docs/guide/compute.qmd
@@ -181,24 +181,12 @@ print("null count:", result.null_count())   # 1
 print("is_valid(3):", result.is_valid(3))   # False
 ```
 
-## String kernels
-
-`string_lengths` returns the byte length of each string element as `uint32`. Null elements produce null output.
-
-```{python}
-s = ma.array(["hello", None, "world", "mañana"])
-print(ma.string_lengths(s))   # [5, NULL, 5, 7]
-```
-
-Note that `mañana` is 7 bytes (the `ñ` character is 2 bytes in UTF-8).
-
 ## Null behaviour summary
 
 | Operation | Null input | Null output |
 |-----------|-----------|-------------|
 | `add`, `sub`, `mul`, `div` | either operand null | null propagates |
-| `equal`, `less`, `greater`, … | either operand null | null propagates |
-| `string_lengths` | element null | null propagates |
+| `equal`, `less`, `greater`, ... | either operand null | null propagates |
 | `sum_`, `product`, `min_`, `max_` | element null | element skipped |
 | `any_`, `all_` | element null | element skipped |
 | `filter_` (source null) | source element null | null preserved in output |

--- a/docs/guide/interop.qmd
+++ b/docs/guide/interop.qmd
@@ -1,29 +1,24 @@
 ---
 title: "PyArrow Interop"
+execute:
+  enabled: false
 ---
 
 Marrow and [PyArrow](https://arrow.apache.org/docs/python/) implement the same Apache Arrow columnar format. This page covers how they relate, where Marrow is faster, and how to exchange data between them at the Mojo level via the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html).
-
-```{python}
-#| echo: false
-import sys
-sys.path.insert(0, "../../python")
-import marrow as ma
-import pyarrow as pa
-```
 
 ## Same data model
 
 Both libraries represent the same Arrow memory layout. An `int64` array in Marrow and in PyArrow are bitwise identical in memory.
 
-```{python}
+```python
+import marrow as ma
+import pyarrow as pa
+
 # Marrow
 ma_arr = ma.array([1, 2, 3, None, 5])
 print("marrow:", ma_arr)
 print("type:  ", ma_arr.type())
-```
 
-```{python}
 # PyArrow
 pa_arr = pa.array([1, 2, 3, None, 5])
 print("pyarrow:", pa_arr)
@@ -36,16 +31,16 @@ When converting Python data to Arrow arrays, Marrow is faster than PyArrow for n
 
 | Array type | marrow | PyArrow | speedup |
 |------------|-------:|--------:|---------|
-| `int64` (explicit type) | 0.37 ms | 0.89 ms | **2.4×** |
-| `int64` + nulls (explicit) | 0.36 ms | 0.87 ms | **2.4×** |
-| `float64` (explicit) | 0.34 ms | 0.48 ms | **1.4×** |
-| `float64` + nulls | 0.34 ms | 0.51 ms | **1.5×** |
-| `string` (explicit) | 0.72 ms | 1.06 ms | **1.5×** |
-| `string` + nulls | 0.70 ms | 1.04 ms | **1.5×** |
-| struct, primitive fields (explicit) | 5.41 ms | 6.54 ms | **1.2×** |
-| `int64` (inferred) | 1.40 ms | 1.27 ms | 1.1× slower |
-| `string` (inferred) | 1.57 ms | 1.02 ms | 1.5× slower |
-| nested list (inferred) | 3.92 ms | 2.36 ms | 1.7× slower |
+| `int64` (explicit type) | 0.37 ms | 0.89 ms | **2.4x** |
+| `int64` + nulls (explicit) | 0.36 ms | 0.87 ms | **2.4x** |
+| `float64` (explicit) | 0.34 ms | 0.48 ms | **1.4x** |
+| `float64` + nulls | 0.34 ms | 0.51 ms | **1.5x** |
+| `string` (explicit) | 0.72 ms | 1.06 ms | **1.5x** |
+| `string` + nulls | 0.70 ms | 1.04 ms | **1.5x** |
+| struct, primitive fields (explicit) | 5.41 ms | 6.54 ms | **1.2x** |
+| `int64` (inferred) | 1.40 ms | 1.27 ms | 1.1x slower |
+| `string` (inferred) | 1.57 ms | 1.02 ms | 1.5x slower |
+| nested list (inferred) | 3.92 ms | 2.36 ms | 1.7x slower |
 
 The pattern: **provide an explicit type when you know it**. Marrow's builder path is highly optimized for known types. When the type must be inferred from a scan of Python objects, PyArrow currently wins for complex nested structures.
 
@@ -61,15 +56,16 @@ Marrow arrays implement the Arrow C Data Interface protocol (`__arrow_c_array__`
 
 ### Python level
 
-```{python}
-# PyArrow → Marrow (via __arrow_c_array__ protocol)
+```python
+import marrow as ma
+import pyarrow as pa
+
+# PyArrow -> Marrow (via __arrow_c_array__ protocol)
 pa_arr = pa.array([1, 2, 3, None, 5])
 ma_arr = ma.array(pa_arr)
 print(ma_arr)
-```
 
-```{python}
-# Marrow → PyArrow (via __arrow_c_array__ protocol)
+# Marrow -> PyArrow (via __arrow_c_array__ protocol)
 ma_arr = ma.array([1, 2, 3, None, 5])
 pa_arr = pa.array(ma_arr)
 print(pa_arr)

--- a/docs/guide/types.qmd
+++ b/docs/guide/types.qmd
@@ -129,14 +129,6 @@ records = ma.array([
 print(records)
 ```
 
-Access fields by position:
-
-```{python}
-print("names: ", records.field(0))
-print("scores:", records.field(1))
-print("ranks: ", records.field(2))
-```
-
 ## Nested list types
 
 List arrays hold variable-length sequences. Type inference handles the common cases automatically:


### PR DESCRIPTION
## Summary
- Remove calls to Python API methods that don't exist yet (`true_count`, `false_count`, `flatten`, `value_lengths`, `field`, `string_lengths`)
- Disable code execution for pages requiring `pyarrow` (interop, datafusion) since the docs pixi env can't install it
- Simplify docs deploy to publish `docs/_site/` directly with `keep_files: true`