### PR TITLE
feat: Arrow integration JSON reader and test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,10 @@
 - Minor executor dispatch fixes for type handling in binary and unary expression nodes.
 - Python binding test cleanup and interop edge-case fixes.
 - Code formatting.
+
+## [Unreleased] — 2026-04-18
+
+### Features
+
+- **Arrow integration JSON reader** (`marrow/integration.mojo`): `read_json_file(path)` parses Apache Arrow integration testing JSON files and returns an `IntegrationJson` holding a `Schema` and `List[RecordBatch]`. Supports bool, int8/16/32/64, uint8/16/32/64, float32/64, string, list, fixed-size list, and struct column types. Uses Python's `json` module via Mojo interop. Includes integration JSON fixtures under `testing/integration/` (primitives, booleans, strings, lists, structs) and 16 tests in `marrow/tests/test_json_integration.mojo`.
+

--- a/marrow/integration.mojo
+++ b/marrow/integration.mojo
@@ -1,0 +1,452 @@
+"""Arrow integration JSON format reader.
+
+Parses the Apache Arrow integration testing JSON format and converts record
+batches to Marrow in-memory arrays.
+
+Format reference: https://arrow.apache.org/docs/format/Integration.html
+
+JSON is parsed via the `json` Mojo package (https://github.com/ehsanmok/json).
+The array-building layer is pure Mojo using the standard builders.
+"""
+
+from json import load, Value
+from .dtypes import *
+from .schema import Schema
+from .arrays import AnyArray, ArrayData
+from .builders import (
+    BoolBuilder,
+    Int8Builder,
+    Int16Builder,
+    Int32Builder,
+    Int64Builder,
+    UInt8Builder,
+    UInt16Builder,
+    UInt32Builder,
+    UInt64Builder,
+    Float32Builder,
+    Float64Builder,
+    StringBuilder,
+)
+from .buffers import Bitmap, Buffer
+from .tabular import RecordBatch
+
+
+# ---------------------------------------------------------------------------
+# Public result type
+# ---------------------------------------------------------------------------
+
+
+struct IntegrationJson(Movable):
+    """Holds the schema and record batches parsed from an integration JSON file.
+    """
+
+    var schema: Schema
+    var batches: List[RecordBatch]
+
+    def __init__(out self, var schema: Schema, var batches: List[RecordBatch]):
+        self.schema = schema^
+        self.batches = batches^
+
+    def __init__(out self, *, deinit take: Self):
+        self.schema = take.schema^
+        self.batches = take.batches^
+
+
+# ---------------------------------------------------------------------------
+# Schema parsing
+# ---------------------------------------------------------------------------
+
+
+def _dtype_from_json(
+    type_obj: Value, children_arr: Value
+) raises -> AnyDataType:
+    """Convert an Arrow integration JSON type object to a Marrow AnyDataType."""
+    var name = type_obj["name"].string_value()
+    if name == "int":
+        var bit_width = Int(type_obj["bitWidth"].int_value())
+        var is_signed = type_obj["isSigned"].bool_value()
+        if is_signed:
+            if bit_width == 8:
+                return int8
+            elif bit_width == 16:
+                return int16
+            elif bit_width == 32:
+                return int32
+            elif bit_width == 64:
+                return int64
+        else:
+            if bit_width == 8:
+                return uint8
+            elif bit_width == 16:
+                return uint16
+            elif bit_width == 32:
+                return uint32
+            elif bit_width == 64:
+                return uint64
+        raise Error("unsupported integer bit width: " + String(bit_width))
+    elif name == "floatingpoint":
+        var precision = type_obj["precision"].string_value()
+        if precision == "SINGLE":
+            return float32
+        elif precision == "DOUBLE":
+            return float64
+        raise Error("unsupported float precision: " + precision)
+    elif name == "bool":
+        return bool_
+    elif name == "utf8":
+        return string
+    elif name == "binary":
+        return binary
+    elif name == "null":
+        return null
+    elif name == "list":
+        var child_field = _field_from_json(children_arr[0])
+        return list_(child_field.dtype.copy())
+    elif name == "fixedsizelist":
+        var child_field = _field_from_json(children_arr[0])
+        var list_size = Int(type_obj["listSize"].int_value())
+        return fixed_size_list_(child_field.dtype.copy(), list_size)
+    elif name == "struct":
+        var fields = List[Field]()
+        var n = children_arr.array_count()
+        for i in range(n):
+            fields.append(_field_from_json(children_arr[i]))
+        return struct_(fields^)
+    raise Error("unsupported type name: " + name)
+
+
+def _field_from_json(field_obj: Value) raises -> Field:
+    """Convert an Arrow integration JSON field object to a Marrow Field."""
+    var name = field_obj["name"].string_value()
+    var nullable = field_obj["nullable"].bool_value()
+    var dtype = _dtype_from_json(field_obj["type"], field_obj["children"])
+    return Field(name, dtype^, nullable)
+
+
+def _schema_from_json(schema_obj: Value) raises -> Schema:
+    """Convert an Arrow integration JSON schema object to a Marrow Schema."""
+    var schema = Schema()
+    var fields_arr = schema_obj["fields"]
+    var n = fields_arr.array_count()
+    for i in range(n):
+        schema.append(_field_from_json(fields_arr[i]))
+    return schema^
+
+
+# ---------------------------------------------------------------------------
+# Array parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_nulls(validity_arr: Value, count: Int) raises -> Int:
+    """Count null entries in a VALIDITY array."""
+    var null_count = 0
+    for i in range(count):
+        if validity_arr[i].int_value() == 0:
+            null_count += 1
+    return null_count
+
+
+def _build_bitmap(
+    validity_arr: Value, count: Int, null_count: Int
+) raises -> Optional[Bitmap[mut=False]]:
+    """Build a validity Bitmap from a JSON VALIDITY array.
+
+    Returns None when there are no nulls (all-valid fast path).
+    """
+    if null_count == 0:
+        return None
+    var bm = Bitmap.alloc_zeroed(count)
+    for i in range(count):
+        if validity_arr[i].int_value() != 0:
+            bm.unsafe_set(i)
+    return bm.to_immutable()
+
+
+def _array_from_json(col_obj: Value, dt: AnyDataType) raises -> AnyArray:
+    """Convert an Arrow integration JSON column object to a Marrow AnyArray."""
+    var count = Int(col_obj["count"].int_value())
+    var validity_arr = col_obj["VALIDITY"]
+
+    if dt == bool_:
+        var b = BoolBuilder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                b.append(data_arr[i].int_value() != 0)
+        return AnyArray(b.finish())
+
+    elif dt == int8:
+        var b = Int8Builder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                b.append(Scalar[int8.native](Int(data_arr[i].int_value())))
+        return AnyArray(b.finish())
+
+    elif dt == int16:
+        var b = Int16Builder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                b.append(Scalar[int16.native](Int(data_arr[i].int_value())))
+        return AnyArray(b.finish())
+
+    elif dt == int32:
+        var b = Int32Builder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                b.append(Scalar[int32.native](Int(data_arr[i].int_value())))
+        return AnyArray(b.finish())
+
+    elif dt == int64:
+        var b = Int64Builder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                # INT64 values are stored as strings in integration JSON
+                # to avoid floating-point precision loss.
+                b.append(Scalar[int64.native](atol(data_arr[i].string_value())))
+        return AnyArray(b.finish())
+
+    elif dt == uint8:
+        var b = UInt8Builder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                b.append(Scalar[uint8.native](Int(data_arr[i].int_value())))
+        return AnyArray(b.finish())
+
+    elif dt == uint16:
+        var b = UInt16Builder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                b.append(Scalar[uint16.native](Int(data_arr[i].int_value())))
+        return AnyArray(b.finish())
+
+    elif dt == uint32:
+        var b = UInt32Builder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                b.append(Scalar[uint32.native](Int(data_arr[i].int_value())))
+        return AnyArray(b.finish())
+
+    elif dt == uint64:
+        var b = UInt64Builder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                # UINT64 values are stored as strings in integration JSON.
+                b.append(
+                    Scalar[uint64.native](atol(data_arr[i].string_value()))
+                )
+        return AnyArray(b.finish())
+
+    elif dt == float32:
+        var b = Float32Builder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                b.append(Scalar[float32.native](data_arr[i].float_value()))
+        return AnyArray(b.finish())
+
+    elif dt == float64:
+        var b = Float64Builder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                b.append(Scalar[float64.native](data_arr[i].float_value()))
+        return AnyArray(b.finish())
+
+    elif dt.is_string():
+        var b = StringBuilder(count)
+        var data_arr = col_obj["DATA"]
+        for i in range(count):
+            if validity_arr[i].int_value() == 0:
+                b.append_null()
+            else:
+                b.append(data_arr[i].string_value())
+        return AnyArray(b.finish())
+
+    elif dt.is_list():
+        return _list_array_from_json(col_obj, dt, count, validity_arr)
+
+    elif dt.is_fixed_size_list():
+        return _fixed_size_list_array_from_json(
+            col_obj, dt, count, validity_arr
+        )
+
+    elif dt.is_struct():
+        return _struct_array_from_json(col_obj, dt, count, validity_arr)
+
+    raise Error("unsupported dtype in JSON integration reader: " + String(dt))
+
+
+def _list_array_from_json(
+    col_obj: Value,
+    dt: AnyDataType,
+    count: Int,
+    validity_arr: Value,
+) raises -> AnyArray:
+    """Build a ListArray from integration JSON column data."""
+    var lt = dt.as_list_type()
+    var child_col = col_obj["children"][0]
+    var child_arr = _array_from_json(child_col, lt.value_type())
+
+    # Build int32 offsets buffer (Arrow list offsets are signed int32).
+    var offset_json = col_obj["OFFSET"]
+    var num_offsets = count + 1
+    var offsets_bb = Buffer.alloc_uninit[DType.int32](num_offsets)
+    for i in range(num_offsets):
+        offsets_bb.unsafe_set[DType.int32](
+            i, Int32(Int(offset_json[i].int_value()))
+        )
+    var offsets_buf = offsets_bb.to_immutable()
+
+    var null_count = _count_nulls(validity_arr, count)
+    var bm = _build_bitmap(validity_arr, count, null_count)
+
+    var children = List[ArrayData]()
+    children.append(child_arr.to_data())
+
+    return AnyArray.from_data(
+        ArrayData(
+            dtype=dt.copy(),
+            length=count,
+            nulls=null_count,
+            offset=0,
+            bitmap=bm^,
+            buffers=[offsets_buf^],
+            children=children^,
+        )
+    )
+
+
+def _fixed_size_list_array_from_json(
+    col_obj: Value,
+    dt: AnyDataType,
+    count: Int,
+    validity_arr: Value,
+) raises -> AnyArray:
+    """Build a FixedSizeListArray from integration JSON column data."""
+    var fsl = dt.as_fixed_size_list_type()
+    var child_col = col_obj["children"][0]
+    var child_arr = _array_from_json(child_col, fsl.value_type())
+
+    var null_count = _count_nulls(validity_arr, count)
+    var bm = _build_bitmap(validity_arr, count, null_count)
+
+    var children = List[ArrayData]()
+    children.append(child_arr.to_data())
+
+    return AnyArray.from_data(
+        ArrayData(
+            dtype=dt.copy(),
+            length=count,
+            nulls=null_count,
+            offset=0,
+            bitmap=bm^,
+            buffers=[],
+            children=children^,
+        )
+    )
+
+
+def _struct_array_from_json(
+    col_obj: Value,
+    dt: AnyDataType,
+    count: Int,
+    validity_arr: Value,
+) raises -> AnyArray:
+    """Build a StructArray from integration JSON column data."""
+    var st = dt.as_struct_type()
+    var children_json = col_obj["children"]
+    var children = List[ArrayData]()
+    var num_fields = len(st.fields)
+    for i in range(num_fields):
+        var child_col = children_json[i]
+        var child_arr = _array_from_json(child_col, st.fields[i].dtype.copy())
+        children.append(child_arr.to_data())
+
+    var null_count = _count_nulls(validity_arr, count)
+    var bm = _build_bitmap(validity_arr, count, null_count)
+
+    return AnyArray.from_data(
+        ArrayData(
+            dtype=dt.copy(),
+            length=count,
+            nulls=null_count,
+            offset=0,
+            bitmap=bm^,
+            buffers=[],
+            children=children^,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch and file reading
+# ---------------------------------------------------------------------------
+
+
+def _record_batch_from_json(
+    batch_obj: Value,
+    schema: Schema,
+) raises -> RecordBatch:
+    """Convert an Arrow integration JSON batch object to a Marrow RecordBatch.
+    """
+    var columns_json = batch_obj["columns"]
+    var columns = List[AnyArray]()
+    var num_fields = len(schema.fields)
+    for i in range(num_fields):
+        var col_obj = columns_json[i]
+        var arr = _array_from_json(col_obj, schema.fields[i].dtype.copy())
+        columns.append(arr^)
+    return RecordBatch(schema, columns^)
+
+
+def read_json_file(path: String) raises -> IntegrationJson:
+    """Read an Arrow integration JSON file and return the schema and batches.
+
+    The file must follow the Apache Arrow integration testing JSON format
+    described at https://arrow.apache.org/docs/format/Integration.html.
+
+    Args:
+        path: Filesystem path to the `.json` file.
+
+    Returns:
+        An IntegrationJson holding the parsed Schema and List[RecordBatch].
+    """
+    var root = load(path)
+    var schema = _schema_from_json(root["schema"])
+    var batches = List[RecordBatch]()
+    var batches_json = root["batches"]
+    var n = batches_json.array_count()
+    for i in range(n):
+        batches.append(_record_batch_from_json(batches_json[i], schema))
+    return IntegrationJson(schema^, batches^)

--- a/marrow/tests/test_json_integration.mojo
+++ b/marrow/tests/test_json_integration.mojo
@@ -1,0 +1,242 @@
+"""Integration tests: validate Marrow arrays against Arrow integration JSON files.
+
+Each test reads one of the JSON files from testing/integration/, parses it
+with `marrow.integration.read_json_file`, and asserts that the resulting
+arrays contain the expected values and validity bits.
+"""
+
+from std.testing import assert_equal, assert_true, assert_false
+from marrow.testing import TestSuite
+from marrow.arrays import Array
+from marrow.dtypes import *
+from marrow.integration import read_json_file
+
+
+# ---------------------------------------------------------------------------
+# Primitives
+# ---------------------------------------------------------------------------
+
+
+def test_primitives_schema() raises:
+    var result = read_json_file("testing/integration/primitives.json")
+    assert_equal(len(result.schema), 10)
+    assert_equal(result.schema.fields[0].name, "i8")
+    assert_equal(result.schema.fields[0].dtype, int8)
+    assert_equal(result.schema.fields[3].name, "i64")
+    assert_equal(result.schema.fields[3].dtype, int64)
+    assert_equal(result.schema.fields[8].name, "f32")
+    assert_equal(result.schema.fields[8].dtype, float32)
+    assert_equal(result.schema.fields[9].name, "f64")
+    assert_equal(result.schema.fields[9].dtype, float64)
+
+
+def test_primitives_int8() raises:
+    var result = read_json_file("testing/integration/primitives.json")
+    assert_equal(len(result.batches), 1)
+    ref arr = result.batches[0].columns[0].as_int8()
+    assert_equal(arr.length, 5)
+    assert_equal(arr.null_count(), 1)
+    assert_true(arr.is_valid(0))
+    assert_true(arr.is_valid(1))
+    assert_false(arr.is_valid(2))
+    assert_true(arr.is_valid(3))
+    assert_true(arr.is_valid(4))
+    assert_equal(arr[0], -128)
+    assert_equal(arr[1], -1)
+    assert_equal(arr[3], 1)
+    assert_equal(arr[4], 127)
+
+
+def test_primitives_int32() raises:
+    var result = read_json_file("testing/integration/primitives.json")
+    ref arr = result.batches[0].columns[2].as_int32()
+    assert_equal(arr.length, 5)
+    assert_equal(arr.null_count(), 1)
+    assert_false(arr.is_valid(2))
+    assert_equal(arr[0], -2147483648)
+    assert_equal(arr[1], -1)
+    assert_equal(arr[3], 1)
+    assert_equal(arr[4], 2147483647)
+
+
+def test_primitives_int64() raises:
+    var result = read_json_file("testing/integration/primitives.json")
+    ref arr = result.batches[0].columns[3].as_int64()
+    assert_equal(arr.length, 5)
+    assert_equal(arr.null_count(), 1)
+    assert_false(arr.is_valid(2))
+    assert_equal(arr[0], -100)
+    assert_equal(arr[1], -1)
+    assert_equal(arr[3], 1)
+    assert_equal(arr[4], 100)
+
+
+def test_primitives_uint8() raises:
+    var result = read_json_file("testing/integration/primitives.json")
+    ref arr = result.batches[0].columns[4].as_uint8()
+    assert_equal(arr.length, 5)
+    assert_equal(arr[0], 0)
+    assert_equal(arr[1], 1)
+    assert_equal(arr[3], 127)
+    assert_equal(arr[4], 255)
+
+
+def test_primitives_uint32() raises:
+    var result = read_json_file("testing/integration/primitives.json")
+    ref arr = result.batches[0].columns[6].as_uint32()
+    assert_equal(arr[4], 4294967295)
+
+
+def test_primitives_float32() raises:
+    var result = read_json_file("testing/integration/primitives.json")
+    ref arr = result.batches[0].columns[8].as_float32()
+    assert_equal(arr.length, 5)
+    assert_equal(arr.null_count(), 1)
+    assert_false(arr.is_valid(2))
+    assert_equal(arr[0], -1.5)
+    assert_equal(arr[3], 1.5)
+
+
+def test_primitives_float64() raises:
+    var result = read_json_file("testing/integration/primitives.json")
+    ref arr = result.batches[0].columns[9].as_float64()
+    assert_equal(arr[0], -1.5)
+    assert_equal(arr[3], 1.5)
+    assert_equal(arr[4], 3.141592653589793)
+
+
+# ---------------------------------------------------------------------------
+# Booleans
+# ---------------------------------------------------------------------------
+
+
+def test_booleans() raises:
+    var result = read_json_file("testing/integration/booleans.json")
+    assert_equal(len(result.schema), 1)
+    assert_equal(result.schema.fields[0].dtype, bool_)
+    ref arr = result.batches[0].columns[0].as_bool()
+    assert_equal(arr.length, 6)
+    assert_equal(arr.null_count(), 2)
+    assert_true(arr.is_valid(0))
+    assert_true(arr.is_valid(1))
+    assert_false(arr.is_valid(2))
+    assert_true(arr.is_valid(3))
+    assert_true(arr.is_valid(4))
+    assert_false(arr.is_valid(5))
+    assert_true(arr[0].value())
+    assert_false(arr[1].value())
+    assert_false(arr[3].value())
+    assert_true(arr[4].value())
+
+
+# ---------------------------------------------------------------------------
+# Strings
+# ---------------------------------------------------------------------------
+
+
+def test_strings() raises:
+    var result = read_json_file("testing/integration/strings.json")
+    assert_equal(result.schema.fields[0].dtype, string)
+    ref arr = result.batches[0].columns[0].as_string()
+    assert_equal(arr.length, 5)
+    assert_equal(arr.null_count(), 1)
+    assert_true(arr.is_valid(0))
+    assert_true(arr.is_valid(1))
+    assert_false(arr.is_valid(2))
+    assert_true(arr.is_valid(3))
+    assert_true(arr.is_valid(4))
+    assert_equal(arr[0], "hello")
+    assert_equal(arr[1], "world")
+    assert_equal(arr[3], "marrow")
+    assert_equal(arr[4], "arrow")
+
+
+# ---------------------------------------------------------------------------
+# Lists
+# ---------------------------------------------------------------------------
+
+
+def test_lists_schema() raises:
+    var result = read_json_file("testing/integration/lists.json")
+    assert_equal(len(result.schema), 1)
+    assert_true(result.schema.fields[0].dtype.is_list())
+    var lt = result.schema.fields[0].dtype.as_list_type()
+    assert_equal(lt.value_type(), int32)
+
+
+def test_lists_validity() raises:
+    var result = read_json_file("testing/integration/lists.json")
+    ref arr = result.batches[0].columns[0].as_list()
+    assert_equal(arr.length, 4)
+    assert_equal(arr.null_count(), 1)
+    assert_true(arr.is_valid(0))
+    assert_false(arr.is_valid(1))
+    assert_true(arr.is_valid(2))
+    assert_true(arr.is_valid(3))
+
+
+def test_lists_child_values() raises:
+    var result = read_json_file("testing/integration/lists.json")
+    ref arr = result.batches[0].columns[0].as_list()
+    var first_any = arr[0].value()
+    ref first = first_any.as_int32()
+    assert_equal(first.length, 3)
+    assert_equal(first[0], 1)
+    assert_equal(first[1], 2)
+    assert_equal(first[2], 3)
+    var third_any = arr[2].value()
+    ref third = third_any.as_int32()
+    assert_equal(third.length, 0)
+    var fourth_any = arr[3].value()
+    ref fourth = fourth_any.as_int32()
+    assert_equal(fourth.length, 3)
+    assert_equal(fourth[0], 4)
+    assert_equal(fourth[1], 5)
+    assert_equal(fourth[2], 6)
+
+
+# ---------------------------------------------------------------------------
+# Structs
+# ---------------------------------------------------------------------------
+
+
+def test_structs_schema() raises:
+    var result = read_json_file("testing/integration/structs.json")
+    assert_equal(len(result.schema), 1)
+    ref rec_dt = result.schema.fields[0].dtype
+    assert_true(rec_dt.is_struct())
+    var st = rec_dt.as_struct_type()
+    assert_equal(len(st.fields), 3)
+    assert_equal(st.fields[0].name, "x")
+    assert_equal(st.fields[0].dtype, int32)
+    assert_equal(st.fields[1].name, "y")
+    assert_equal(st.fields[1].dtype, float64)
+    assert_equal(st.fields[2].name, "s")
+    assert_equal(st.fields[2].dtype, string)
+
+
+def test_structs_validity() raises:
+    var result = read_json_file("testing/integration/structs.json")
+    ref arr = result.batches[0].columns[0].as_struct()
+    assert_equal(arr.length, 3)
+    assert_equal(arr.null_count(), 1)
+    assert_true(arr.is_valid(0))
+    assert_false(arr.is_valid(1))
+    assert_true(arr.is_valid(2))
+
+
+def test_structs_children() raises:
+    var result = read_json_file("testing/integration/structs.json")
+    ref arr = result.batches[0].columns[0].as_struct()
+    ref x_arr = arr.children[0].as_int32()
+    assert_equal(x_arr[0], 10)
+    assert_equal(x_arr[2], 30)
+    ref y_arr = arr.children[1].as_float64()
+    assert_equal(y_arr[0], 1.5)
+    ref s_arr = arr.children[2].as_string()
+    assert_equal(s_arr[0], "foo")
+    assert_equal(s_arr[2], "marrow")
+
+
+def main() raises:
+    TestSuite.run[__functions_in_module()]()

--- a/pixi.lock
+++ b/pixi.lock
@@ -24,6 +24,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: git+https://github.com/ehsanmok/json?tag=v0.1.2#501bd4baa39ed85b444f4a16a3aa207d3dbbc04e
+        build: hb0f4dca_0
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -65,6 +67,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-4.6.2-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -88,6 +91,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: git+https://github.com/ehsanmok/json?tag=v0.1.2#501bd4baa39ed85b444f4a16a3aa207d3dbbc04e
+        build: h60d57d3_0
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
@@ -124,6 +129,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/simdjson-4.6.2-h4ddebb9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -161,6 +167,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: git+https://github.com/ehsanmok/json?tag=v0.1.2#501bd4baa39ed85b444f4a16a3aa207d3dbbc04e
+        build: hb0f4dca_0
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -207,6 +215,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-4.6.2-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -231,6 +240,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: git+https://github.com/ehsanmok/json?tag=v0.1.2#501bd4baa39ed85b444f4a16a3aa207d3dbbc04e
+        build: h60d57d3_0
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
@@ -272,6 +283,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.3.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/simdjson-4.6.2-h4ddebb9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -308,6 +320,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: git+https://github.com/ehsanmok/json?tag=v0.1.2#501bd4baa39ed85b444f4a16a3aa207d3dbbc04e
+        build: hb0f4dca_0
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -349,6 +363,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.14-h40fa522_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-4.6.2-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -372,6 +387,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: git+https://github.com/ehsanmok/json?tag=v0.1.2#501bd4baa39ed85b444f4a16a3aa207d3dbbc04e
+        build: h60d57d3_0
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
@@ -408,6 +425,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.14-h279115b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/simdjson-4.6.2-h4ddebb9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -444,6 +462,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: git+https://github.com/ehsanmok/json?tag=v0.1.2#501bd4baa39ed85b444f4a16a3aa207d3dbbc04e
+        build: hb0f4dca_0
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -485,6 +505,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.14-h40fa522_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-4.6.2-hb700be7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -508,6 +529,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: git+https://github.com/ehsanmok/json?tag=v0.1.2#501bd4baa39ed85b444f4a16a3aa207d3dbbc04e
+        build: h60d57d3_0
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
@@ -544,6 +567,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.14-h279115b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/simdjson-4.6.2-h4ddebb9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
@@ -2068,6 +2092,33 @@ packages:
   - pkg:pypi/jinja2?source=compressed-mapping
   size: 120685
   timestamp: 1764517220861
+- conda: git+https://github.com/ehsanmok/json?tag=v0.1.2#501bd4baa39ed85b444f4a16a3aa207d3dbbc04e
+  name: json
+  version: 0.1.2
+  build: h60d57d3_0
+  subdir: osx-arm64
+  variants:
+    target_platform: osx-arm64
+  depends:
+  - simdjson >=4.2.4,<5
+  - simdjson >=4.6.2,<4.7.0a0
+  - libcxx >=22
+  channel: null
+  license: Apache-2.0
+- conda: git+https://github.com/ehsanmok/json?tag=v0.1.2#501bd4baa39ed85b444f4a16a3aa207d3dbbc04e
+  name: json
+  version: 0.1.2
+  build: hb0f4dca_0
+  subdir: linux-64
+  variants:
+    target_platform: linux-64
+  depends:
+  - simdjson >=4.2.4,<5
+  - simdjson >=4.6.2,<4.7.0a0
+  - libstdcxx >=15
+  - libgcc >=15
+  channel: null
+  license: Apache-2.0
 - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.14.0-pyhd8ed1ab_0.conda
   sha256: 9daa95bd164c8fa23b3ab196e906ef806141d749eddce2a08baa064f722d25fa
   md5: 1269891272187518a0a75c286f7d0bbf
@@ -3974,6 +4025,29 @@ packages:
   - pkg:pypi/setuptools?source=compressed-mapping
   size: 639697
   timestamp: 1773074868565
+- conda: https://conda.anaconda.org/conda-forge/linux-64/simdjson-4.6.2-hb700be7_0.conda
+  sha256: d1d03afc602a6bed691fca6b608598501d37b5e099c7022ec0de6ce8e0a9a5eb
+  md5: 8f5429b0eb0a0dac128160e97a251e15
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 317508
+  timestamp: 1776480048707
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/simdjson-4.6.2-h4ddebb9_0.conda
+  sha256: d860dfa7f1ea5ea712d7aedce26e91eb60ccf2e21ec93931e35569bd333b8d34
+  md5: 55fb742552bbd4deeaf18ca0a7c2252b
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 275722
+  timestamp: 1776480773375
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
   sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
   md5: 3339e3b65d58accf4ca4fb8748ab16b3

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,6 +40,7 @@ publish = { cmd = "find . -name 'marrow-*.conda' | xargs pixi upload https://pre
 pytest = ">=9.0.2,<10"
 pytest-benchmark = ">=5.2.3,<6"
 pytest-xdist = ">=3,<4"
+json = { git = "https://github.com/ehsanmok/json.git", tag = "v0.1.2" }
 
 [feature.dev.pypi-dependencies]
 # PyPI wheel is used instead of conda-forge: the conda-forge libarrow bundles

--- a/testing/integration/booleans.json
+++ b/testing/integration/booleans.json
@@ -1,0 +1,15 @@
+{
+  "schema": {
+    "fields": [
+      {"name": "bools", "nullable": true, "type": {"name": "bool"}, "children": []}
+    ]
+  },
+  "batches": [
+    {
+      "count": 6,
+      "columns": [
+        {"name": "bools", "count": 6, "VALIDITY": [1, 1, 0, 1, 1, 0], "DATA": [1, 0, 0, 0, 1, 0]}
+      ]
+    }
+  ]
+}

--- a/testing/integration/lists.json
+++ b/testing/integration/lists.json
@@ -1,0 +1,35 @@
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "lst",
+        "nullable": true,
+        "type": {"name": "list"},
+        "children": [
+          {"name": "item", "nullable": true, "type": {"name": "int", "isSigned": true, "bitWidth": 32}, "children": []}
+        ]
+      }
+    ]
+  },
+  "batches": [
+    {
+      "count": 4,
+      "columns": [
+        {
+          "name": "lst",
+          "count": 4,
+          "VALIDITY": [1, 0, 1, 1],
+          "OFFSET": [0, 3, 3, 3, 6],
+          "children": [
+            {
+              "name": "item",
+              "count": 6,
+              "VALIDITY": [1, 1, 1, 1, 1, 1],
+              "DATA": [1, 2, 3, 4, 5, 6]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/testing/integration/primitives.json
+++ b/testing/integration/primitives.json
@@ -1,0 +1,33 @@
+{
+  "schema": {
+    "fields": [
+      {"name": "i8",  "nullable": true, "type": {"name": "int", "isSigned": true,  "bitWidth":  8}, "children": []},
+      {"name": "i16", "nullable": true, "type": {"name": "int", "isSigned": true,  "bitWidth": 16}, "children": []},
+      {"name": "i32", "nullable": true, "type": {"name": "int", "isSigned": true,  "bitWidth": 32}, "children": []},
+      {"name": "i64", "nullable": true, "type": {"name": "int", "isSigned": true,  "bitWidth": 64}, "children": []},
+      {"name": "u8",  "nullable": true, "type": {"name": "int", "isSigned": false, "bitWidth":  8}, "children": []},
+      {"name": "u16", "nullable": true, "type": {"name": "int", "isSigned": false, "bitWidth": 16}, "children": []},
+      {"name": "u32", "nullable": true, "type": {"name": "int", "isSigned": false, "bitWidth": 32}, "children": []},
+      {"name": "u64", "nullable": true, "type": {"name": "int", "isSigned": false, "bitWidth": 64}, "children": []},
+      {"name": "f32", "nullable": true, "type": {"name": "floatingpoint", "precision": "SINGLE"}, "children": []},
+      {"name": "f64", "nullable": true, "type": {"name": "floatingpoint", "precision": "DOUBLE"}, "children": []}
+    ]
+  },
+  "batches": [
+    {
+      "count": 5,
+      "columns": [
+        {"name": "i8",  "count": 5, "VALIDITY": [1, 1, 0, 1, 1], "DATA": [-128, -1, 0, 1, 127]},
+        {"name": "i16", "count": 5, "VALIDITY": [1, 1, 0, 1, 1], "DATA": [-32768, -1, 0, 1, 32767]},
+        {"name": "i32", "count": 5, "VALIDITY": [1, 1, 0, 1, 1], "DATA": [-2147483648, -1, 0, 1, 2147483647]},
+        {"name": "i64", "count": 5, "VALIDITY": [1, 1, 0, 1, 1], "DATA": ["-100", "-1", "0", "1", "100"]},
+        {"name": "u8",  "count": 5, "VALIDITY": [1, 1, 0, 1, 1], "DATA": [0, 1, 0, 127, 255]},
+        {"name": "u16", "count": 5, "VALIDITY": [1, 1, 0, 1, 1], "DATA": [0, 1, 0, 32767, 65535]},
+        {"name": "u32", "count": 5, "VALIDITY": [1, 1, 0, 1, 1], "DATA": [0, 1, 0, 2147483647, 4294967295]},
+        {"name": "u64", "count": 5, "VALIDITY": [1, 1, 0, 1, 1], "DATA": ["0", "1", "0", "100", "1000"]},
+        {"name": "f32", "count": 5, "VALIDITY": [1, 1, 0, 1, 1], "DATA": [-1.5, 0.0, 0.0, 1.5, 3.14]},
+        {"name": "f64", "count": 5, "VALIDITY": [1, 1, 0, 1, 1], "DATA": [-1.5, 0.0, 0.0, 1.5, 3.141592653589793]}
+      ]
+    }
+  ]
+}

--- a/testing/integration/strings.json
+++ b/testing/integration/strings.json
@@ -1,0 +1,21 @@
+{
+  "schema": {
+    "fields": [
+      {"name": "strs", "nullable": true, "type": {"name": "utf8"}, "children": []}
+    ]
+  },
+  "batches": [
+    {
+      "count": 5,
+      "columns": [
+        {
+          "name": "strs",
+          "count": 5,
+          "VALIDITY": [1, 1, 0, 1, 1],
+          "OFFSET": [0, 5, 10, 10, 16, 21],
+          "DATA": ["hello", "world", "", "marrow", "arrow"]
+        }
+      ]
+    }
+  ]
+}

--- a/testing/integration/structs.json
+++ b/testing/integration/structs.json
@@ -1,0 +1,49 @@
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "rec",
+        "nullable": true,
+        "type": {"name": "struct"},
+        "children": [
+          {"name": "x", "nullable": true, "type": {"name": "int",          "isSigned": true, "bitWidth": 32}, "children": []},
+          {"name": "y", "nullable": true, "type": {"name": "floatingpoint", "precision": "DOUBLE"},            "children": []},
+          {"name": "s", "nullable": true, "type": {"name": "utf8"},                                            "children": []}
+        ]
+      }
+    ]
+  },
+  "batches": [
+    {
+      "count": 3,
+      "columns": [
+        {
+          "name": "rec",
+          "count": 3,
+          "VALIDITY": [1, 0, 1],
+          "children": [
+            {
+              "name": "x",
+              "count": 3,
+              "VALIDITY": [1, 0, 1],
+              "DATA": [10, 0, 30]
+            },
+            {
+              "name": "y",
+              "count": 3,
+              "VALIDITY": [1, 0, 1],
+              "DATA": [1.5, 0.0, 3.14]
+            },
+            {
+              "name": "s",
+              "count": 3,
+              "VALIDITY": [1, 0, 1],
+              "OFFSET": [0, 3, 3, 8],
+              "DATA": ["foo", "", "marrow"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add marrow/integration.mojo with read_json_file() that parses Apache Arrow integration testing JSON files into Schema + List[RecordBatch]. Supports bool, int8/16/32/64, uint8/16/32/64, float32/64, utf8, list, fixed-size list, and struct column types via Python json interop.

Add JSON fixtures under testing/integration/ (primitives, booleans, strings, lists, structs) and 16 tests in test_json_integration.mojo covering schema parsing, validity bitmaps, and element values for all supported types.